### PR TITLE
fix(ui): prevent compact launcher tree overlap

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,7 @@
         "width": 1200,
         "height": 800,
         "minWidth": 350,
-        "minHeight": 500
+        "minHeight": 600
       }
     ],
     "security": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ const appStartAt =
     : Date.now();
 let firstScreenPerfReported = false;
 const COMPACT_WINDOW_WIDTH = 350;
-const WINDOW_MIN_HEIGHT = 500;
+const WINDOW_MIN_HEIGHT = 600;
 const IN_TAURI = isTauri();
 
 function App() {

--- a/src/components/sidebar/ProjectTree.tsx
+++ b/src/components/sidebar/ProjectTree.tsx
@@ -265,7 +265,7 @@ export function ProjectTree({
 
   if (initialLoading) {
     return (
-      <div className="flex-1 overflow-y-auto px-1.5 pb-2 pt-1">
+      <div className="h-full overflow-y-auto px-1.5 pb-2 pt-1">
         <SidebarSkeleton />
       </div>
     );
@@ -276,7 +276,7 @@ export function ProjectTree({
     const collapsedButtonSize = density === "compact" ? "h-7 w-7" : "h-8 w-8";
     const compactTextSize = density === "compact" ? "text-[11px]" : "text-xs";
     return (
-      <div className={`flex-1 overflow-y-auto ${density === "compact" ? "px-0.5 pb-1.5 pt-0.5" : "px-1 pb-2 pt-1"}`}>
+      <div className={`h-full overflow-y-auto ${density === "compact" ? "px-0.5 pb-1.5 pt-0.5" : "px-1 pb-2 pt-1"}`}>
         {compactItems.length === 0 && (
           <div className={`flex flex-col items-center text-text-muted ${density === "compact" ? "gap-1.5 py-2.5" : "gap-2 py-3"}`}>
             <Terminal size={20} strokeWidth={1.2} className="opacity-50" />
@@ -332,7 +332,7 @@ export function ProjectTree({
   }
 
   return (
-    <div className={`flex-1 overflow-y-auto ${density === "compact" ? "px-1 pb-1.5 pt-0.5" : "px-1.5 pb-2 pt-1"}`}>
+    <div className={`h-full overflow-y-auto ${density === "compact" ? "px-1 pb-1.5 pt-0.5" : "px-1.5 pb-2 pt-1"}`}>
       {newGroupParentId === "__root__" && (
         <div className={`flex items-center px-2 ${density === "compact" ? "gap-1 py-1" : "gap-1.5 py-1.5"}`}>
           <span className="shrink-0 text-accent">

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -654,7 +654,7 @@ export function Sidebar({ onOpenStats, compactMode = false }: SidebarProps) {
         />
       </div>
 
-      <div className="min-h-0 flex-1">
+      <div className={`${compactMode ? "min-h-[220px]" : "min-h-0"} flex-1 overflow-hidden`}>
         <TreeContext.Provider value={treeActions}>
           <ProjectTree
             tree={tree}
@@ -678,7 +678,7 @@ export function Sidebar({ onOpenStats, compactMode = false }: SidebarProps) {
         </TreeContext.Provider>
       </div>
 
-      <div className="ui-sidebar-footer">
+      <div className="ui-sidebar-footer shrink-0">
         <SidebarFooter
           collapsed={compactMode ? false : sidebarCollapsed}
           useExternalTerminal={useExternalTerminal}


### PR DESCRIPTION
Raise the app minimum height for compact mode resizing and keep the project tree in its own scrollable region above the footer.