### PR TITLE
fix: adapt macOS window controls

### DIFF
--- a/scripts/verify-macos-window-controls.mjs
+++ b/scripts/verify-macos-window-controls.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const macosConfig = JSON.parse(await readFile("src-tauri/tauri.macos.conf.json", "utf8"));
+const mainWindow = macosConfig?.app?.windows?.[0];
+
+assert.equal(
+  mainWindow?.decorations,
+  true,
+  "macOS config must enable native decorations so the system traffic-light controls are available"
+);
+assert.equal(
+  mainWindow?.titleBarStyle,
+  "Visible",
+  "macOS config must use a separate native title bar so it cannot intercept webview controls"
+);
+assert.equal(
+  mainWindow?.hiddenTitle,
+  true,
+  "macOS config must hide the native title text because the app renders its own title"
+);
+assert.equal(
+  mainWindow?.trafficLightPosition,
+  undefined,
+  "macOS config must not use overlay traffic-light positioning"
+);
+
+const titleBarSource = await readFile("src/components/WindowTitleBar.tsx", "utf8");
+const appSource = await readFile("src/App.tsx", "utf8");
+const sidebarSource = await readFile("src/components/sidebar/index.tsx", "utf8");
+
+assert.match(
+  titleBarSource,
+  /isMacOs/,
+  "WindowTitleBar must detect macOS before deciding whether to render custom controls"
+);
+assert.match(
+  titleBarSource,
+  /if \(isMacOs\) return null/,
+  "WindowTitleBar must not render custom webview chrome on macOS"
+);
+assert.match(
+  titleBarSource,
+  /!isMacOs && IN_TAURI/,
+  "WindowTitleBar must not render custom Windows-style controls on macOS"
+);
+assert.match(
+  appSource,
+  /if \(!IN_TAURI \|\| isMacOs\) return;/,
+  "App must not force window size changes on macOS native window management"
+);
+assert.match(
+  sidebarSource,
+  /if \(compactMode \|\| isMacOs\) return;/,
+  "Sidebar must not auto-collapse on macOS native split-screen resize"
+);
+
+console.log("macOS window controls verification passed");

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -3,7 +3,9 @@
     "windows": [
       {
         "title": "CLI-Manager",
-        "decorations": false,
+        "decorations": true,
+        "titleBarStyle": "Visible",
+        "hiddenTitle": true,
         "center": true,
         "width": 1200,
         "height": 800,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import { useModelPricingStore } from "./stores/modelPricingStore";
 import { createPerfMarker, logWarn } from "./lib/logger";
 import { getContrastRatioFromHex, MIN_APPLY_CONTRAST_RATIO } from "./lib/contrast";
 import { translateCurrent, useI18n } from "./lib/i18n";
+import { getOsPlatform } from "./lib/shell";
 import "./App.css";
 
 const appStartAt =
@@ -50,6 +51,10 @@ const IN_TAURI = isTauri();
 const CLAUDE_HOOK_TOAST_PREFIX = "claude-hook-notification";
 let claudeHookToastSequence = 0;
 type HookInstallStatus = "directoryMissing" | "notInstalled" | "partialInstalled" | "installed";
+
+function isLikelyMacOs() {
+  return typeof navigator !== "undefined" && /mac/i.test(navigator.platform);
+}
 
 interface HookSettingsStatusPayload {
   claude: { status: HookInstallStatus };
@@ -344,6 +349,7 @@ function App() {
   const [statsOpen, setStatsOpen] = useState(false);
   const [closeDialogOpen, setCloseDialogOpen] = useState(false);
   const [terminalFullscreen, setTerminalFullscreen] = useState(false);
+  const [isMacOs, setIsMacOs] = useState(isLikelyMacOs);
   const terminalFullscreenMaximizedRef = useRef(false);
   const restoreWindowWidthRef = useRef<number | null>(null);
   const closeBehaviorRef = useRef(closeBehavior);
@@ -357,6 +363,13 @@ function App() {
   useEffect(() => {
     closeBehaviorRef.current = closeBehavior;
   }, [closeBehavior]);
+
+  useEffect(() => {
+    if (!IN_TAURI) return;
+    void getOsPlatform()
+      .then((platform) => setIsMacOs(platform === "macos"))
+      .catch((err) => logWarn("Failed to read OS platform for window sizing", err));
+  }, []);
 
   const runCloseAutoSync = useCallback(async () => {
     const result = await useSyncStore.getState().runAutoSync("close");
@@ -717,7 +730,7 @@ function App() {
   );
 
   useEffect(() => {
-    if (!IN_TAURI) return;
+    if (!IN_TAURI || isMacOs) return;
     const appWindow = getCurrentWindow();
     void (async () => {
       try {
@@ -753,7 +766,7 @@ function App() {
         logWarn("Failed to adjust window size", err);
       }
     })();
-  }, [viewMode, settingsOpen]);
+  }, [isMacOs, viewMode, settingsOpen]);
 
   useEffect(() => {
     if (firstScreenPerfReported) return;

--- a/src/components/WindowTitleBar.tsx
+++ b/src/components/WindowTitleBar.tsx
@@ -3,17 +3,30 @@ import { isTauri } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Copy, Minus, Square, X } from "lucide-react";
 import { logWarn } from "../lib/logger";
+import { getOsPlatform } from "../lib/shell";
 import appIcon32 from "../assets/app-icon-32.png";
 import { useI18n } from "../lib/i18n";
 
 const IN_TAURI = isTauri();
 
+function isLikelyMacOs() {
+  return typeof navigator !== "undefined" && /mac/i.test(navigator.platform);
+}
+
 export function WindowTitleBar() {
   const { t } = useI18n();
+  const [isMacOs, setIsMacOs] = useState(isLikelyMacOs);
   const [maximized, setMaximized] = useState(false);
 
   useEffect(() => {
     if (!IN_TAURI) return;
+    void getOsPlatform()
+      .then((platform) => setIsMacOs(platform === "macos"))
+      .catch((err) => logWarn("Failed to read OS platform for title bar", err));
+  }, []);
+
+  useEffect(() => {
+    if (!IN_TAURI || isMacOs) return;
     const appWindow = getCurrentWindow();
     let mounted = true;
     let unlisten: (() => void) | null = null;
@@ -46,7 +59,7 @@ export function WindowTitleBar() {
         unlisten();
       }
     };
-  }, []);
+  }, [isMacOs]);
 
   const runWindowAction = (action: () => Promise<void>) => {
     if (!IN_TAURI) return;
@@ -54,6 +67,8 @@ export function WindowTitleBar() {
       logWarn("Window title bar action failed", err);
     });
   };
+
+  if (isMacOs) return null;
 
   return (
     <header className="window-titlebar flex h-[26px] shrink-0 items-center bg-surface-container-low">
@@ -70,7 +85,7 @@ export function WindowTitleBar() {
         />
         <span className="truncate text-[13px] font-semibold tracking-[0.005em] text-on-surface">CLI-Manager</span>
       </div>
-      {IN_TAURI && (
+      {!isMacOs && IN_TAURI && (
         <div className="flex items-center">
           <button
             type="button"

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -41,6 +41,7 @@ import {
 import { openPath } from "@tauri-apps/plugin-opener";
 import type { SettingsTab } from "../SettingsModal";
 import { useI18n } from "../../lib/i18n";
+import { getOsPlatform } from "../../lib/shell";
 
 interface SidebarProps {
   onOpenSettings: (tab?: SettingsTab) => void;
@@ -53,6 +54,11 @@ const SIDEBAR_COLLAPSE_THRESHOLD = 140;
 const SIDEBAR_MIN_WIDTH = 168;
 const SIDEBAR_MAX_WIDTH = 500;
 const SIDEBAR_AUTO_COLLAPSE_BREAKPOINT = 900;
+const IN_TAURI = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+
+function isLikelyMacOs() {
+  return typeof navigator !== "undefined" && /mac/i.test(navigator.platform);
+}
 
 function clampExpandedSidebarWidth(width: number): number {
   return Math.max(SIDEBAR_MIN_WIDTH, Math.min(SIDEBAR_MAX_WIDTH, width));
@@ -133,6 +139,7 @@ export function Sidebar({ onOpenSettings, onOpenStats, compactMode = false }: Si
     initialSidebarWidth <= SIDEBAR_COLLAPSED_WIDTH
   );
   const [sidebarResizing, setSidebarResizing] = useState(false);
+  const [isMacOs, setIsMacOs] = useState(isLikelyMacOs);
 
   const liveSidebarWidthRef = useRef(initialSidebarWidth);
   const isResizingRef = useRef(false);
@@ -219,6 +226,13 @@ export function Sidebar({ onOpenSettings, onOpenStats, compactMode = false }: Si
   const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!IN_TAURI) return;
+    void getOsPlatform()
+      .then((platform) => setIsMacOs(platform === "macos"))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
     if (compactMode) {
       setSidebarCollapsed(false);
       return;
@@ -300,7 +314,7 @@ export function Sidebar({ onOpenSettings, onOpenStats, compactMode = false }: Si
   }, [sidebarCollapsed, expandSidebar]);
 
   useEffect(() => {
-    if (compactMode) return;
+    if (compactMode || isMacOs) return;
     const syncViewportCollapse = () => {
       if (window.innerWidth < SIDEBAR_AUTO_COLLAPSE_BREAKPOINT) {
         if (!sidebarCollapsed) {
@@ -323,7 +337,7 @@ export function Sidebar({ onOpenSettings, onOpenStats, compactMode = false }: Si
     return () => {
       window.removeEventListener("resize", syncViewportCollapse);
     };
-  }, [compactMode, sidebarCollapsed, collapseSidebar, expandSidebar]);
+  }, [compactMode, isMacOs, sidebarCollapsed, collapseSidebar, expandSidebar]);
 
   const startResize = useCallback(
     (e: ReactMouseEvent) => {


### PR DESCRIPTION
  ## Summary

  - macOS 单独启用原生窗口装饰，使用系统红黄绿 traffic-light 按钮与原生绿色按钮菜单。
  - macOS 下不再渲染前端自定义标题栏，避免与系统窗口控制、分屏/全屏行为冲突。
  - macOS 下跳过前端窗口尺寸强制调整与侧边栏 resize 自动折叠逻辑，修复分屏后项目树展开闪烁问题。
  - Windows/Linux 保持原有自定义标题栏与窗口控制逻辑不变。

  ## Impact

  - 影响范围集中在 macOS 窗口控制与 macOS 分屏场景。
  - 共享前端组件中的变更均通过 `isMacOs` 分支隔离。
  - 未修改后端 PTY、数据库、历史会话、项目管理等业务逻辑。
  - GitNexus 影响分析显示 `App`、`WindowTitleBar`、`Sidebar` 上游影响均为 LOW；`detect_changes` 标记
  为 medium 的原因是 `App`/`Sidebar` 属于前端入口组件，实际变更未扩散到非 macOS 专属路径。

  ## Verification

  - [x] `node scripts/verify-macos-window-controls.mjs`
  - [x] `npx tsc --noEmit`
  - [x] `git diff --check`
  - [x] macOS 本地手动验证：关闭、最小化、最大化/Move & Resize、左右分屏、项目树展开行为正常