### PR TITLE
fix: stop titlebar resize maximize polling

### DIFF
--- a/src/components/WindowTitleBar.tsx
+++ b/src/components/WindowTitleBar.tsx
@@ -16,7 +16,6 @@ export function WindowTitleBar() {
     if (!IN_TAURI) return;
     const appWindow = getCurrentWindow();
     let mounted = true;
-    let unlisten: (() => void) | null = null;
 
     const syncMaximized = async () => {
       try {
@@ -29,30 +28,26 @@ export function WindowTitleBar() {
       }
     };
 
-    void (async () => {
-      await syncMaximized();
-      try {
-        unlisten = await appWindow.onResized(() => {
-          void syncMaximized();
-        });
-      } catch (err) {
-        logWarn("Failed to listen to window resize event", err);
-      }
-    })();
+    void syncMaximized();
 
     return () => {
       mounted = false;
-      if (unlisten) {
-        unlisten();
-      }
     };
   }, []);
 
-  const runWindowAction = (action: () => Promise<void>) => {
+  const runWindowAction = (source: string, action: () => Promise<void>) => {
     if (!IN_TAURI) return;
-    void action().catch((err) => {
-      logWarn("Window title bar action failed", err);
-    });
+    void (async () => {
+      try {
+        await action();
+        if (source === "toggleMaximize") {
+          const next = await getCurrentWindow().isMaximized();
+          setMaximized(next);
+        }
+      } catch (err) {
+        logWarn("Window title bar action failed", { source, err });
+      }
+    })();
   };
 
   return (
@@ -60,7 +55,7 @@ export function WindowTitleBar() {
       <div
         className="flex min-w-0 flex-1 items-center gap-2 px-2.5 text-[13px]"
         data-tauri-drag-region
-        onDoubleClick={() => runWindowAction(() => getCurrentWindow().toggleMaximize())}
+        onDoubleClick={() => runWindowAction("toggleMaximize", () => getCurrentWindow().toggleMaximize())}
       >
         <img
           src={appIcon32}
@@ -77,7 +72,7 @@ export function WindowTitleBar() {
             className="titlebar-btn"
             aria-label={t("window.minimize")}
             title={t("window.minimize")}
-            onClick={() => runWindowAction(() => getCurrentWindow().minimize())}
+            onClick={() => runWindowAction("minimize", () => getCurrentWindow().minimize())}
           >
             <Minus size={14} />
           </button>
@@ -86,7 +81,7 @@ export function WindowTitleBar() {
             className="titlebar-btn"
             aria-label={maximized ? t("window.restore") : t("window.maximize")}
             title={maximized ? t("window.restore") : t("window.maximize")}
-            onClick={() => runWindowAction(() => getCurrentWindow().toggleMaximize())}
+            onClick={() => runWindowAction("toggleMaximize", () => getCurrentWindow().toggleMaximize())}
           >
             {maximized ? <Copy size={12} /> : <Square size={12} />}
           </button>
@@ -95,7 +90,7 @@ export function WindowTitleBar() {
             className="titlebar-btn titlebar-btn-close"
             aria-label={t("window.close")}
             title={t("window.close")}
-            onClick={() => runWindowAction(() => getCurrentWindow().close())}
+            onClick={() => runWindowAction("close", () => getCurrentWindow().close())}
           >
             <X size={14} />
           </button>


### PR DESCRIPTION

  ## Summary
  - Remove the titlebar resize listener that repeatedly queried `appWindow.isMaximized()`.
  - Refresh maximize button state only on mount and after explicit maximize toggle actions.

  ## Root Cause
  Switching `Settings -> General -> Follow System` can trigger repeated macOS window resize/style updates. The titlebar
  resize handler called `appWindow.isMaximized()` on every resize event, which entered Tauri/tao macOS window state code
  and repeatedly hit `NSWindow setStyleMask`, causing `cli-manager` CPU to spike above 100%.

  ## Validation
  - Reproduced on master with PID 33067 at ~107% CPU.
  - Sample confirmed hot stack: `tauri_runtime_wry -> tao::window::Window::is_maximized -> NSWindow setStyleMask`.
  - Verified fixed locally after removing resize polling.
  - `npx tsc --noEmit`
  - `git diff --check`
  - `npx gitnexus detect-changes --repo CLI-Manager`

  与 fix/macos-native-window-controls 的冲突解决方案

  重叠文件：

  - src/App.tsx
  - src/components/WindowTitleBar.tsx

  实际冲突点主要在 WindowTitleBar.tsx。建议合并时：

  - 保留 fix/macos-native-window-controls 的 macOS 原生标题栏逻辑：macOS 下 WindowTitleBar 返回 null。
  - 同时保留本分支的修复：非 macOS 下也不要恢复 appWindow.onResized(() => syncMaximized())。
  - 最大化状态只在 mount 和显式 toggleMaximize 后同步。