### PR TITLE
fix: 修复 macOS GUI 启动终端颜色丢失

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@lobehub/icons": "^5.10.0",
+        "@lobehub/icons": "^5.10.1",
         "@mantine/core": "^9.3.1",
         "@mantine/hooks": "^9.3.1",
         "@monaco-editor/react": "^4.7.0",
@@ -1445,9 +1445,9 @@
       }
     },
     "node_modules/@lobehub/icons": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmmirror.com/@lobehub/icons/-/icons-5.10.0.tgz",
-      "integrity": "sha512-CIpjkISCLRK7haDtSugGFd0o3odaJts8ewJOkUiEFtns3xvsqbl8i24eowBnjw+yMDQVQyNONlhqTD58YC6Ljg==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@lobehub/icons/-/icons-5.10.1.tgz",
+      "integrity": "sha512-KMaE+YqPAXuA8gcmzBFefLa9KgCqmJy9Mg3tlGedrL2coAzCQeps+aqivjejHNMnCDTPnGb+OHvX1um2kT1lQw==",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@lobehub/icons": "^5.10.0",
+    "@lobehub/icons": "^5.10.1",
     "@mantine/core": "^9.3.1",
     "@mantine/hooks": "^9.3.1",
     "@monaco-editor/react": "^4.7.0",

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -519,9 +519,29 @@ PS0='\e]133;C\a${PS0:0:$((__cli_manager_ran=1,0))}'
         if let Some(dir) = cwd {
             cmd.cwd(dir);
         }
-        if let Some(vars) = env_vars {
+        if let Some(ref vars) = env_vars {
             for (k, v) in vars {
                 cmd.env(k, v);
+            }
+        }
+        // 非 Windows：GUI 启动（Dock/Finder）时父进程没有 TERM，子进程继承空 TERM
+        // 会导致 claude/codex/ls/git 等判定为非彩色终端而禁用 ANSI 颜色。
+        // 显式注入 xterm-256color（xterm.js 完整支持）+ truecolor，让支持的工具走 24-bit。
+        // 仅在调用方未自定义时补默认值，尊重用户偏好。
+        if !cfg!(target_os = "windows") {
+            let has_term = env_vars
+                .as_ref()
+                .map(|v| v.contains_key("TERM"))
+                .unwrap_or(false);
+            if !has_term {
+                cmd.env("TERM", "xterm-256color");
+            }
+            let has_colorterm = env_vars
+                .as_ref()
+                .map(|v| v.contains_key("COLORTERM"))
+                .unwrap_or(false);
+            if !has_colorterm {
+                cmd.env("COLORTERM", "truecolor");
             }
         }
 


### PR DESCRIPTION

## 错误截图

最新的1.2.4版本
<img width="1892" height="1530" alt="image" src="https://github.com/user-attachments/assets/851911f1-c18f-4934-ab97-82898244756e" />

## 根因

PTY 子进程在 macOS 下继承了空的 `TERM` 环境变量。

- Tauri 打包成 `.app` 从 Dock 启动时，父进程（LaunchServices 拉起）环境里**没有 `TERM`**（`TERM` 只在从 Terminal 启动时存在）。
- `PtyManager::create` 用 `CommandBuilder` 创建子进程，仅注入前端传来的 `env_vars`，未显式设置 `TERM`。
- 子进程继承空 `TERM` → `claude` / `codex`（Node.js 的 picocolors / chalk）、`ls`、`grep`、`git` 等普遍逻辑是 `isatty && TERM && TERM !== "dumb"` 才启用颜色。`TERM` 为空时即使 stdout 是 PTY 也会降级为无色。
- Windows 不受影响：ConPTY 下 PowerShell 用 `$PSStyle`、Node.js 走 Windows 控制台 API，不依赖 `TERM`。
- 开发模式 `npm run tauri dev` 从终端拉起，`TERM` 被继承所以颜色正常，掩盖了该 bug——这也是它容易被忽略的原因。

## 修复

### 1. 注入 TERM / COLORTERM（`src-tauri/src/pty/manager.rs`）

在 `PtyManager::create` 非 Windows 分支显式注入终端能力声明：

- `TERM=xterm-256color`：xterm.js 完整支持 256 色
- `COLORTERM=truecolor`：让支持 24-bit 的工具（新版 ls / bat / claude 等）走真彩色

仅在调用方未自定义时补默认值，尊重用户偏好（不覆盖已有的 `TERM` / `COLORTERM`）。

### 2. 升级 @lobehub/icons 5.10.0 → 5.10.1

打包链路上一个**已存在的依赖损坏问题**：5.10.0 发布的 tarball 缺失 `es/Codex` 子模块，rollup 解析 `icons.js` 的 re-export 时报 `Could not resolve "./Codex"`，导致 `vite build` / `tauri build` 失败。5.10.1 已补齐。代码只用到 12 个具名图标，未使用 Codex，运行时无影响。

## 验证
1. `cargo check` 通过
2. 用 dev 模式抹掉 TERM 复现 Dock 启动的丢色环境：
   ```bash
   env -u TERM -u COLORTERM npm run tauri dev
3. 应用终端内执行 echo "TERM=$TERM COLORTERM=$COLORTERM"，修复前为空、修复后输出 xterm-256color / truecolor
4. 启动 claude / codex，颜色输出正常

<img width="1894" height="1554" alt="image" src="https://github.com/user-attachments/assets/88b8e22d-ff21-4101-83a0-94fb011be9b4" />

改动范围
- src-tauri/src/pty/manager.rs：+21 / -1
- package.json / package-lock.json：依赖补丁版本