### PR TITLE
fix: stabilize terminal file drag drops

### DIFF
--- a/src/components/XTermTerminal.tsx
+++ b/src/components/XTermTerminal.tsx
@@ -27,7 +27,12 @@ import { resolveManualDirectCodexEnterData } from "../lib/codexManualInput";
 import { debugConsoleWarn } from "../lib/debugConsole";
 import { useI18n } from "../lib/i18n";
 import { normalizeTerminalFontFamily } from "../lib/terminalFontFamily";
-import { endTerminalFileDrag, getTerminalFileDragText } from "../lib/terminalFileDrag";
+import {
+  endTerminalFileDrag,
+  getTerminalFileDragText,
+  registerTerminalDropZone,
+  updateTerminalFileDragPointFromEvent,
+} from "../lib/terminalFileDrag";
 import { planTerminalVisibilityRestore, refreshTerminalViewport } from "../lib/terminalVisibility";
 import {
   defaultShellForOs,
@@ -259,6 +264,15 @@ const quoteShellPath = (path: string, shell: string | null | undefined) => {
 const formatShellPathList = (paths: string[], shell: string | null | undefined) => (
   paths.filter(Boolean).map((path) => quoteShellPath(path, shell)).join(" ")
 );
+
+const hasDataTransferType = (dataTransfer: DataTransfer | null, type: string): boolean => {
+  if (!dataTransfer) return false;
+  const types = dataTransfer.types as DataTransfer["types"] & {
+    contains?: (value: string) => boolean;
+  };
+  if (typeof types.contains === "function") return types.contains(type);
+  return Array.from(types).includes(type);
+};
 
 const openHttpUrl = (sessionId: string, uri: string) => {
   if (!/^https?:\/\//i.test(uri)) return;
@@ -1295,8 +1309,17 @@ export function XTermTerminal({ sessionId, isActive = true, isVisible = true, fo
     };
 
     const hasTerminalFileDragData = (dataTransfer: DataTransfer | null) => (
-      Boolean(getTerminalFileDragText()) || Boolean(dataTransfer?.types.includes(TERMINAL_FILE_PATH_MIME))
+      Boolean(getTerminalFileDragText()) || hasDataTransferType(dataTransfer, TERMINAL_FILE_PATH_MIME)
     );
+    const unregisterTerminalDropZone = registerTerminalDropZone({
+      id: sessionId,
+      getRect: () => {
+        if (!isVisibleRef.current) return null;
+        return pasteTarget.getBoundingClientRect();
+      },
+      paste: pasteIntoTerminal,
+      focus: () => terminal.focus(),
+    });
     const getShellForPathQuoting = async () => {
       const os = await getOsPlatformForPathQuoting();
       const session = useTerminalStore.getState().sessions.find((item) => item.id === sessionId);
@@ -1308,7 +1331,8 @@ export function XTermTerminal({ sessionId, isActive = true, isVisible = true, fo
 
     const onDragOver = (e: DragEvent) => {
       const isActiveTerminalFileDrag = Boolean(getTerminalFileDragText());
-      if (!isActiveTerminalFileDrag && (!isPointInsidePasteTarget(e.clientX, e.clientY) || !hasTerminalFileDragData(e.dataTransfer))) return;
+      if (isActiveTerminalFileDrag) updateTerminalFileDragPointFromEvent(e);
+      if (!isPointInsidePasteTarget(e.clientX, e.clientY) || !hasTerminalFileDragData(e.dataTransfer)) return;
       e.preventDefault();
       e.stopPropagation();
       if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
@@ -1317,6 +1341,7 @@ export function XTermTerminal({ sessionId, isActive = true, isVisible = true, fo
       if (!isPointInsidePasteTarget(e.clientX, e.clientY) || !hasTerminalFileDragData(e.dataTransfer)) return;
       const text = getTerminalFileDragText()
         || e.dataTransfer?.getData(TERMINAL_FILE_PATH_MIME)
+        || e.dataTransfer?.getData("text/plain")
         || "";
       e.preventDefault();
       e.stopPropagation();
@@ -2040,6 +2065,7 @@ export function XTermTerminal({ sessionId, isActive = true, isVisible = true, fo
       cancelled = true;
       cancelPendingCursorShow();
       pasteTarget.removeEventListener("paste", onPaste, pasteListenerOptions);
+      unregisterTerminalDropZone();
       window.removeEventListener("dragover", onDragOver, true);
       window.removeEventListener("drop", onDrop, true);
       fileDropCancelled = true;

--- a/src/components/files/FileExplorerSidebar.tsx
+++ b/src/components/files/FileExplorerSidebar.tsx
@@ -1,4 +1,14 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type DragEvent as ReactDragEvent, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type DragEvent as ReactDragEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { getMaterialFileIcon, getMaterialFolderIcon } from "@baybreezy/file-extension-icon";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
@@ -7,7 +17,13 @@ import { copyAiText } from "../../lib/aiClipboard";
 import { formatAiPathBlock, formatAiRootTree, formatAiTree, formatTerminalDragPath, TERMINAL_FILE_PATH_MIME } from "../../lib/aiPathFormatter";
 import { debugConsoleWarn } from "../../lib/debugConsole";
 import { useI18n, type TranslationKey } from "../../lib/i18n";
-import { beginTerminalFileDrag, endTerminalFileDrag } from "../../lib/terminalFileDrag";
+import {
+  beginTerminalFileDrag,
+  commitTerminalFileDragDrop,
+  endTerminalFileDrag,
+  getTerminalFileDropZoneIdAtPoint,
+  updateTerminalFileDragPointFromEvent,
+} from "../../lib/terminalFileDrag";
 import type { GitFileChange, ProjectFileContentMatch, ProjectFileEntry, ProjectFileSearchMode } from "../../lib/types";
 import { isDefaultCollapsedDirectoryName, useFileExplorerStore } from "../../stores/fileExplorerStore";
 import { useSettingsStore } from "../../stores/settingsStore";
@@ -47,6 +63,7 @@ type Translate = ReturnType<typeof useI18n>["t"];
 
 const FILE_EXPLORER_ENTRY_MIME = "application/x-cli-manager-file-entry";
 const FILE_WATCH_REFRESH_DEBOUNCE_MS = 600;
+const POINTER_DRAG_START_PX = 6;
 
 interface AutoCollapseGroupState {
   expandedGroupPaths: Set<string>;
@@ -54,6 +71,31 @@ interface AutoCollapseGroupState {
   toggleGroup: (parentPath: string) => void;
   ignorePath: (path: string) => void;
   unignorePath: (path: string) => void;
+}
+
+interface FilePointerDragState {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  entry: ProjectFileEntry;
+  preview: FileDragPreviewSource;
+  dragging: boolean;
+}
+
+interface FileDragPreviewSource {
+  className: string;
+  html: string;
+  offsetX: number;
+  offsetY: number;
+  paddingLeft: string;
+  width: number;
+}
+
+interface FileDragPreviewState {
+  x: number;
+  y: number;
+  source: FileDragPreviewSource;
+  overTerminal: boolean;
 }
 
 const GIT_STATUS_LABELS: Record<GitFileChange["status"], TranslationKey> = {
@@ -326,9 +368,14 @@ function FileNode({
   onRenameCancel,
   onFileKeyDown,
   onFileDragStart,
+  onFileDrag,
   onFileDragEnd,
   onFileDragOver,
   onFileDrop,
+  onFilePointerDown,
+  onFilePointerMove,
+  onFilePointerUp,
+  onFilePointerCancel,
   autoCollapseGroups,
   menuPortalContainer,
 }: {
@@ -345,9 +392,14 @@ function FileNode({
   onRenameCancel: () => void;
   onFileKeyDown: (event: ReactKeyboardEvent<HTMLElement>, entry: ProjectFileEntry) => void;
   onFileDragStart: (event: ReactDragEvent<HTMLElement>, entry: ProjectFileEntry) => void;
-  onFileDragEnd: () => void;
+  onFileDrag: (event: ReactDragEvent<HTMLElement>) => void;
+  onFileDragEnd: (event: ReactDragEvent<HTMLElement>) => void;
   onFileDragOver: (event: ReactDragEvent<HTMLElement>, targetEntry: ProjectFileEntry) => void;
   onFileDrop: (event: ReactDragEvent<HTMLElement>, targetEntry: ProjectFileEntry) => void;
+  onFilePointerDown: (event: ReactPointerEvent<HTMLElement>, entry: ProjectFileEntry) => void;
+  onFilePointerMove: (event: ReactPointerEvent<HTMLElement>) => void;
+  onFilePointerUp: (event: ReactPointerEvent<HTMLElement>) => void;
+  onFilePointerCancel: (event: ReactPointerEvent<HTMLElement>) => void;
   autoCollapseGroups: AutoCollapseGroupState;
   menuPortalContainer: HTMLDivElement | null;
 }) {
@@ -415,9 +467,14 @@ function FileNode({
       onRenameCancel={onRenameCancel}
       onFileKeyDown={onFileKeyDown}
       onFileDragStart={onFileDragStart}
+      onFileDrag={onFileDrag}
       onFileDragEnd={onFileDragEnd}
       onFileDragOver={onFileDragOver}
       onFileDrop={onFileDrop}
+      onFilePointerDown={onFilePointerDown}
+      onFilePointerMove={onFilePointerMove}
+      onFilePointerUp={onFilePointerUp}
+      onFilePointerCancel={onFilePointerCancel}
       autoCollapseGroups={autoCollapseGroups}
       menuPortalContainer={menuPortalContainer}
       renderAutoCollapsedGroup={false}
@@ -459,7 +516,8 @@ function FileNode({
             tabIndex={0}
             className="ui-file-tree-row flex w-full items-center gap-1.5 rounded px-1 py-1 text-left text-[12px]"
             data-selected={activePath === displayEntry.path ? "true" : "false"}
-            draggable
+            data-file-drop-target-path={displayEntry.kind === "directory" ? displayEntry.path : parentPath(displayEntry.path)}
+            draggable={false}
             style={{ paddingLeft }}
             title={displayStatus ? `${displayEntry.path} · ${displayStatus.label}` : displayEntry.path}
             onContextMenu={(event) => event.stopPropagation()}
@@ -472,10 +530,16 @@ function FileNode({
               else onOpenFile(displayEntry);
             }}
             onDragStart={(event) => onFileDragStart(event, displayEntry)}
+            onDrag={onFileDrag}
             onDragEnd={onFileDragEnd}
             onDragOver={(event) => onFileDragOver(event, displayEntry)}
             onDrop={(event) => onFileDrop(event, displayEntry)}
-            onClick={() => {
+            onPointerDown={(event) => onFilePointerDown(event, displayEntry)}
+            onPointerMove={onFilePointerMove}
+            onPointerUp={onFilePointerUp}
+            onPointerCancel={onFilePointerCancel}
+            onClick={(event) => {
+              if (event.currentTarget.dataset.pointerDragHandled === "true") return;
               if (isDir) toggleDirectory();
               else onOpenFile(displayEntry);
             }}
@@ -589,9 +653,14 @@ function FileTreeRows({
   onRenameCancel,
   onFileKeyDown,
   onFileDragStart,
+  onFileDrag,
   onFileDragEnd,
   onFileDragOver,
   onFileDrop,
+  onFilePointerDown,
+  onFilePointerMove,
+  onFilePointerUp,
+  onFilePointerCancel,
   autoCollapseGroups,
   menuPortalContainer,
   renderAutoCollapsedGroup,
@@ -610,9 +679,14 @@ function FileTreeRows({
   onRenameCancel: () => void;
   onFileKeyDown: (event: ReactKeyboardEvent<HTMLElement>, entry: ProjectFileEntry) => void;
   onFileDragStart: (event: ReactDragEvent<HTMLElement>, entry: ProjectFileEntry) => void;
-  onFileDragEnd: () => void;
+  onFileDrag: (event: ReactDragEvent<HTMLElement>) => void;
+  onFileDragEnd: (event: ReactDragEvent<HTMLElement>) => void;
   onFileDragOver: (event: ReactDragEvent<HTMLElement>, targetEntry: ProjectFileEntry) => void;
   onFileDrop: (event: ReactDragEvent<HTMLElement>, targetEntry: ProjectFileEntry) => void;
+  onFilePointerDown: (event: ReactPointerEvent<HTMLElement>, entry: ProjectFileEntry) => void;
+  onFilePointerMove: (event: ReactPointerEvent<HTMLElement>) => void;
+  onFilePointerUp: (event: ReactPointerEvent<HTMLElement>) => void;
+  onFilePointerCancel: (event: ReactPointerEvent<HTMLElement>) => void;
   autoCollapseGroups: AutoCollapseGroupState;
   menuPortalContainer: HTMLDivElement | null;
   renderAutoCollapsedGroup: boolean;
@@ -641,9 +715,14 @@ function FileTreeRows({
           onRenameCancel={onRenameCancel}
           onFileKeyDown={onFileKeyDown}
           onFileDragStart={onFileDragStart}
+          onFileDrag={onFileDrag}
           onFileDragEnd={onFileDragEnd}
           onFileDragOver={onFileDragOver}
           onFileDrop={onFileDrop}
+          onFilePointerDown={onFilePointerDown}
+          onFilePointerMove={onFilePointerMove}
+          onFilePointerUp={onFilePointerUp}
+          onFilePointerCancel={onFilePointerCancel}
           autoCollapseGroups={autoCollapseGroups}
           menuPortalContainer={menuPortalContainer}
         />
@@ -672,9 +751,14 @@ function FileTreeRows({
               onRenameCancel={onRenameCancel}
               onFileKeyDown={onFileKeyDown}
               onFileDragStart={onFileDragStart}
+              onFileDrag={onFileDrag}
               onFileDragEnd={onFileDragEnd}
               onFileDragOver={onFileDragOver}
               onFileDrop={onFileDrop}
+              onFilePointerDown={onFilePointerDown}
+              onFilePointerMove={onFilePointerMove}
+              onFilePointerUp={onFilePointerUp}
+              onFilePointerCancel={onFilePointerCancel}
               autoCollapseGroups={autoCollapseGroups}
               menuPortalContainer={menuPortalContainer}
             />
@@ -721,7 +805,9 @@ export function FileExplorerSidebar({ mode = "sidebar", onClosePanel, onBackToPr
   const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
   const [expandedAutoCollapseGroups, setExpandedAutoCollapseGroups] = useState<Set<string>>(new Set());
   const [searchControlsVisible, setSearchControlsVisible] = useState(false);
+  const [dragPreview, setDragPreview] = useState<FileDragPreviewState | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const pointerDragRef = useRef<FilePointerDragState | null>(null);
 
   useEffect(() => {
     setExpandedAutoCollapseGroups(new Set());
@@ -970,6 +1056,35 @@ export function FileExplorerSidebar({ mode = "sidebar", onClosePanel, onBackToPr
     entry.kind === "directory" ? entry.path : parentPath(entry.path)
   ), []);
 
+  const getPointerDropTargetPath = useCallback((x: number, y: number): string | null => {
+    const element = document.elementFromPoint(x, y);
+    const target = element?.closest<HTMLElement>("[data-file-drop-target-path]");
+    if (!target) return null;
+    return target.dataset.fileDropTargetPath ?? "";
+  }, []);
+
+  const markPointerDragHandled = useCallback((element: HTMLElement) => {
+    element.dataset.pointerDragHandled = "true";
+    window.setTimeout(() => {
+      delete element.dataset.pointerDragHandled;
+    }, 0);
+  }, []);
+
+  const resetPointerDrag = useCallback(() => {
+    pointerDragRef.current = null;
+    setDragPreview(null);
+    document.body.style.removeProperty("user-select");
+  }, []);
+
+  const updateDragPreview = useCallback((source: FileDragPreviewSource, x: number, y: number) => {
+    setDragPreview({
+      x: x - source.offsetX,
+      y: y - source.offsetY,
+      source,
+      overTerminal: Boolean(getTerminalFileDropZoneIdAtPoint(x, y)),
+    });
+  }, []);
+
   const focusSearchInput = useCallback(() => {
     window.requestAnimationFrame(() => searchInputRef.current?.focus());
   }, []);
@@ -1033,15 +1148,109 @@ export function FileExplorerSidebar({ mode = "sidebar", onClosePanel, onBackToPr
     if (!project) return;
     const text = formatTerminalDragPath(project, entry.path, entry.kind);
     beginTerminalFileDrag(text);
+    updateTerminalFileDragPointFromEvent(event);
     event.dataTransfer.effectAllowed = "copyMove";
     event.dataTransfer.setData(FILE_EXPLORER_ENTRY_MIME, JSON.stringify({ kind: entry.kind, name: entry.name, path: entry.path }));
     event.dataTransfer.setData(TERMINAL_FILE_PATH_MIME, text);
     event.dataTransfer.setData("text/plain", text);
   }, [project]);
 
-  const handleFileDragEnd = useCallback(() => {
+  const handleFileDrag = useCallback((event: ReactDragEvent<HTMLElement>) => {
+    updateTerminalFileDragPointFromEvent(event);
+  }, []);
+
+  useEffect(() => {
+    const updateDragPoint = (event: DragEvent) => {
+      updateTerminalFileDragPointFromEvent(event);
+    };
+    window.addEventListener("dragover", updateDragPoint, true);
+    window.addEventListener("drop", updateDragPoint, true);
+    return () => {
+      window.removeEventListener("dragover", updateDragPoint, true);
+      window.removeEventListener("drop", updateDragPoint, true);
+    };
+  }, []);
+
+  const handleFileDragEnd = useCallback((event: ReactDragEvent<HTMLElement>) => {
+    updateTerminalFileDragPointFromEvent(event);
+    if (commitTerminalFileDragDrop()) return;
     endTerminalFileDrag();
   }, []);
+
+  const handleFilePointerDown = useCallback((event: ReactPointerEvent<HTMLElement>, entry: ProjectFileEntry) => {
+    if (!project || event.button !== 0 || event.ctrlKey || event.metaKey || event.altKey) return;
+    if (event.pointerType === "mouse" && event.buttons !== 1) return;
+    const rect = event.currentTarget.getBoundingClientRect();
+    pointerDragRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      entry,
+      preview: {
+        className: event.currentTarget.className,
+        html: event.currentTarget.innerHTML,
+        offsetX: event.clientX - rect.left,
+        offsetY: event.clientY - rect.top,
+        paddingLeft: event.currentTarget.style.paddingLeft,
+        width: rect.width,
+      },
+      dragging: false,
+    };
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+  }, [project]);
+
+  const handleFilePointerMove = useCallback((event: ReactPointerEvent<HTMLElement>) => {
+    const state = pointerDragRef.current;
+    if (!state || state.pointerId !== event.pointerId) return;
+
+    if (!state.dragging) {
+      const dx = event.clientX - state.startX;
+      const dy = event.clientY - state.startY;
+      if (Math.hypot(dx, dy) < POINTER_DRAG_START_PX) return;
+      state.dragging = true;
+      if (!project) {
+        resetPointerDrag();
+        return;
+      }
+      beginTerminalFileDrag(formatTerminalDragPath(project, state.entry.path, state.entry.kind));
+      document.body.style.userSelect = "none";
+    }
+
+    updateTerminalFileDragPointFromEvent(event);
+    updateDragPreview(state.preview, event.clientX, event.clientY);
+    event.preventDefault();
+    event.stopPropagation();
+  }, [project, resetPointerDrag, updateDragPreview]);
+
+  const handleFilePointerUp = useCallback((event: ReactPointerEvent<HTMLElement>) => {
+    const state = pointerDragRef.current;
+    if (!state || state.pointerId !== event.pointerId) return;
+
+    if (!state.dragging) {
+      resetPointerDrag();
+      return;
+    }
+
+    markPointerDragHandled(event.currentTarget);
+    updateTerminalFileDragPointFromEvent(event);
+    if (!commitTerminalFileDragDrop()) {
+      const targetPath = getPointerDropTargetPath(event.clientX, event.clientY);
+      if (targetPath !== null) void moveDraggedEntry(state.entry, targetPath);
+      endTerminalFileDrag();
+    }
+
+    event.currentTarget.releasePointerCapture?.(event.pointerId);
+    event.preventDefault();
+    event.stopPropagation();
+    resetPointerDrag();
+  }, [getPointerDropTargetPath, markPointerDragHandled, moveDraggedEntry, resetPointerDrag]);
+
+  const handleFilePointerCancel = useCallback((event: ReactPointerEvent<HTMLElement>) => {
+    const state = pointerDragRef.current;
+    if (!state || state.pointerId !== event.pointerId) return;
+    endTerminalFileDrag();
+    resetPointerDrag();
+  }, [resetPointerDrag]);
 
   const handleFileDragOver = useCallback((event: ReactDragEvent<HTMLElement>, _targetEntry: ProjectFileEntry) => {
     if (!hasFileExplorerDrag(event.dataTransfer)) return;
@@ -1167,8 +1376,12 @@ export function FileExplorerSidebar({ mode = "sidebar", onClosePanel, onBackToPr
             tabIndex={0}
             className="ui-file-tree-row flex w-full items-center gap-2 rounded px-2 py-1 text-left text-[12px]"
             data-selected={activeFile?.path === entry.path ? "true" : "false"}
-            draggable
-            onClick={() => entry.kind === "file" ? requestOpenFile(entry) : undefined}
+            data-file-drop-target-path={getDropTargetPath(entry)}
+            draggable={false}
+            onClick={(event) => {
+              if (event.currentTarget.dataset.pointerDragHandled === "true") return;
+              if (entry.kind === "file") requestOpenFile(entry);
+            }}
             onContextMenu={(event) => event.stopPropagation()}
             onKeyDown={(event) => {
               handleFileKeyDown(event, entry);
@@ -1178,9 +1391,14 @@ export function FileExplorerSidebar({ mode = "sidebar", onClosePanel, onBackToPr
               if (entry.kind === "file") requestOpenFile(entry);
             }}
             onDragStart={(event) => handleFileDragStart(event, entry)}
+            onDrag={handleFileDrag}
             onDragEnd={handleFileDragEnd}
             onDragOver={(event) => handleFileDragOver(event, entry)}
             onDrop={(event) => handleFileDrop(event, entry)}
+            onPointerDown={(event) => handleFilePointerDown(event, entry)}
+            onPointerMove={handleFilePointerMove}
+            onPointerUp={handleFilePointerUp}
+            onPointerCancel={handleFilePointerCancel}
             title={displayStatus ? `${entry.path} · ${displayStatus.label}` : entry.path}
           >
             <img src={entry.kind === "directory" ? getMaterialFolderIcon(entry.name, false) : getMaterialFileIcon(entry.name)} alt="" width={16} height={16} draggable={false} />
@@ -1223,7 +1441,7 @@ export function FileExplorerSidebar({ mode = "sidebar", onClosePanel, onBackToPr
       </ContextMenu>
     );
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeFile?.path, cancelRename, getDisplayStatus, getGitChange, handleFileDragEnd, handleFileDragOver, handleFileDragStart, handleFileDrop, handleFileKeyDown, menuPortalContainer, openFile, project, renamingAction?.path, requestOpenDiff, submitRename, t]);
+  }, [activeFile?.path, cancelRename, getDisplayStatus, getDropTargetPath, getGitChange, handleFileDragEnd, handleFileDragOver, handleFileDragStart, handleFileDrop, handleFileKeyDown, handleFilePointerCancel, handleFilePointerDown, handleFilePointerMove, handleFilePointerUp, menuPortalContainer, openFile, project, renamingAction?.path, requestOpenDiff, submitRename, t]);
 
   const copyRootAiPath = useCallback(() => {
     if (!project) return;
@@ -1273,9 +1491,14 @@ export function FileExplorerSidebar({ mode = "sidebar", onClosePanel, onBackToPr
         onRenameCancel={cancelRename}
         onFileKeyDown={handleFileKeyDown}
         onFileDragStart={handleFileDragStart}
+        onFileDrag={handleFileDrag}
         onFileDragEnd={handleFileDragEnd}
         onFileDragOver={handleFileDragOver}
         onFileDrop={handleFileDrop}
+        onFilePointerDown={handleFilePointerDown}
+        onFilePointerMove={handleFilePointerMove}
+        onFilePointerUp={handleFilePointerUp}
+        onFilePointerCancel={handleFilePointerCancel}
         autoCollapseGroups={autoCollapseGroups}
         menuPortalContainer={menuPortalContainer}
         renderAutoCollapsedGroup
@@ -1284,7 +1507,7 @@ export function FileExplorerSidebar({ mode = "sidebar", onClosePanel, onBackToPr
       <div className="px-3 py-8 text-center text-xs text-text-muted">{t("files.empty")}</div>
     );
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasSearchQuery, searchLoading, searchMode, contentSearchResults, renderContentSearchRow, visibleRows, renderSearchRow, getDisplayStatus, getGitChange, requestOpenDiff, autoCollapseGroups, menuPortalContainer, handleFileKeyDown, handleFileDragStart, handleFileDragEnd, renamingAction?.path, submitRename, cancelRename, t]);
+  }, [hasSearchQuery, searchLoading, searchMode, contentSearchResults, renderContentSearchRow, visibleRows, renderSearchRow, getDisplayStatus, getGitChange, requestOpenDiff, autoCollapseGroups, menuPortalContainer, handleFileKeyDown, handleFileDragStart, handleFileDrag, handleFileDragEnd, handleFileDragOver, handleFileDrop, handleFilePointerCancel, handleFilePointerDown, handleFilePointerMove, handleFilePointerUp, renamingAction?.path, submitRename, cancelRename, t]);
 
   if (!project) return null;
 
@@ -1329,6 +1552,20 @@ export function FileExplorerSidebar({ mode = "sidebar", onClosePanel, onBackToPr
 
   return (
     <div ref={setMenuPortalContainer} className="ui-file-explorer-sidebar flex h-full min-h-0 flex-col" style={panelStyle} onKeyDown={handleSidebarKeyDown}>
+      {dragPreview && (
+        <div
+          className="ui-file-drag-preview"
+          data-over-terminal={dragPreview.overTerminal ? "true" : undefined}
+          style={{ left: dragPreview.x, top: dragPreview.y, width: dragPreview.source.width }}
+          aria-hidden="true"
+        >
+          <div
+            className={dragPreview.source.className}
+            style={dragPreview.source.paddingLeft ? { paddingLeft: dragPreview.source.paddingLeft } : undefined}
+            dangerouslySetInnerHTML={{ __html: dragPreview.source.html }}
+          />
+        </div>
+      )}
       <div className="shrink-0 border-b border-border px-2 py-2">
         <div className="mb-2 flex items-center gap-2">
           <span className="flex shrink-0 cursor-pointer" title={project.path} onDoubleClick={openProjectRootFolder}>
@@ -1396,6 +1633,7 @@ export function FileExplorerSidebar({ mode = "sidebar", onClosePanel, onBackToPr
           <div
             className="min-h-0 flex-1 overflow-y-auto px-1 py-1 outline-none ui-thin-scroll"
             tabIndex={0}
+            data-file-drop-target-path=""
             onKeyDown={handleRootKeyDown}
             onDragOver={handleRootDragOver}
             onDrop={handleRootDrop}

--- a/src/lib/terminalFileDrag.ts
+++ b/src/lib/terminalFileDrag.ts
@@ -2,16 +2,103 @@ interface TerminalFileDragPayload {
   text: string;
 }
 
+interface TerminalDropZone {
+  id: string;
+  getRect: () => DOMRect | null;
+  paste: (text: string) => void;
+  focus: () => void;
+}
+
+interface TerminalDragPointEvent {
+  clientX: number;
+  clientY: number;
+  pageX: number;
+  pageY: number;
+  screenX: number;
+  screenY: number;
+}
+
 let currentDrag: TerminalFileDragPayload | null = null;
+let lastPoint: { x: number; y: number } | null = null;
+const dropZones = new Map<string, TerminalDropZone>();
+
+function isUsableCoordinate(x: number, y: number): boolean {
+  return Number.isFinite(x) && Number.isFinite(y) && (x !== 0 || y !== 0);
+}
+
+function getDropZoneAtPoint(x: number, y: number): TerminalDropZone | null {
+  const zones = Array.from(dropZones.values()).reverse();
+  for (const zone of zones) {
+    const rect = zone.getRect();
+    if (!rect || rect.width <= 0 || rect.height <= 0) continue;
+    const inside = x >= rect.left
+      && x <= rect.right
+      && y >= rect.top
+      && y <= rect.bottom;
+    if (inside) return zone;
+  }
+  return null;
+}
 
 export function beginTerminalFileDrag(text: string) {
   currentDrag = text ? { text } : null;
+  lastPoint = null;
 }
 
 export function endTerminalFileDrag() {
   currentDrag = null;
+  lastPoint = null;
 }
 
 export function getTerminalFileDragText(): string {
   return currentDrag?.text ?? "";
+}
+
+export function updateTerminalFileDragPoint(x: number, y: number) {
+  if (!currentDrag) return;
+  if (!isUsableCoordinate(x, y)) return;
+  lastPoint = { x, y };
+}
+
+export function updateTerminalFileDragPointFromEvent(event: TerminalDragPointEvent) {
+  if (isUsableCoordinate(event.clientX, event.clientY)) {
+    updateTerminalFileDragPoint(event.clientX, event.clientY);
+    return;
+  }
+
+  if (isUsableCoordinate(event.pageX, event.pageY)) {
+    updateTerminalFileDragPoint(event.pageX - window.scrollX, event.pageY - window.scrollY);
+    return;
+  }
+
+  if (!isUsableCoordinate(event.screenX, event.screenY)) return;
+  const screenLeft = window.screenX || window.screenLeft || 0;
+  const screenTop = window.screenY || window.screenTop || 0;
+  updateTerminalFileDragPoint(event.screenX - screenLeft, event.screenY - screenTop);
+}
+
+export function registerTerminalDropZone(zone: TerminalDropZone) {
+  dropZones.set(zone.id, zone);
+  return () => {
+    dropZones.delete(zone.id);
+  };
+}
+
+export function getTerminalFileDropZoneIdAtPoint(x: number, y: number): string | null {
+  if (!isUsableCoordinate(x, y)) return null;
+  return getDropZoneAtPoint(x, y)?.id ?? null;
+}
+
+export function commitTerminalFileDragDrop(): boolean {
+  if (!currentDrag || !lastPoint) return false;
+
+  const zone = getDropZoneAtPoint(lastPoint.x, lastPoint.y);
+  if (zone) {
+    zone.paste(currentDrag.text);
+    zone.focus();
+    endTerminalFileDrag();
+    return true;
+  }
+
+  return false;
 }

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -5314,6 +5314,33 @@
   color: var(--primary);
 }
 
+.ui-file-drag-preview {
+  position: fixed;
+  z-index: 10000;
+  max-width: min(360px, calc(100vw - 24px));
+  pointer-events: none;
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  border-radius: 6px;
+  background-color: color-mix(in srgb, var(--surface-container-high) 94%, transparent);
+  color: var(--on-surface);
+  box-shadow: 0 14px 34px color-mix(in srgb, #000 34%, transparent);
+  opacity: 0.94;
+  overflow: hidden;
+}
+
+.ui-file-drag-preview[data-over-terminal="true"] {
+  border-color: color-mix(in srgb, var(--primary) 72%, transparent);
+  background-color: color-mix(in srgb, var(--primary) 16%, var(--surface-container-high));
+  box-shadow:
+    0 14px 34px color-mix(in srgb, #000 34%, transparent),
+    0 0 0 3px color-mix(in srgb, var(--primary) 18%, transparent);
+}
+
+.ui-file-drag-preview .ui-file-tree-row {
+  width: 100%;
+  background-color: transparent;
+}
+
 .ui-file-explorer-sidebar .ui-icon-action {
   border-color: color-mix(in srgb, var(--on-surface) 10%, transparent);
   background-color: color-mix(in srgb, var(--on-surface) 7%, transparent);


### PR DESCRIPTION
Fix unreliable file path insertion when dragging files from the app file panel into the terminal, especially on macOS WebKit where HTML5 drag data can be inconsistent.

Use a pointer-driven internal drag path with robust DataTransfer type checks as fallback, preserve the original file-row drag preview, and keep external OS file drops on the existing Tauri path.

不影响UI动画效果的前提下。
Mac平台修复前：
<img width="632" height="426" alt="bug" src="https://github.com/user-attachments/assets/c813e622-a636-47e9-aedd-7a8f3a1be9fd" />

Mac平台修复后：
<img width="632" height="426" alt="修复后" src="https://github.com/user-attachments/assets/b7fb6b81-5879-409c-b90a-7366abbc74ff" />

