### PR TITLE
build(tauri): add bundle prep script and adjust git2 dependency

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3395,6 +3395,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3402,6 +3411,7 @@ checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,8 +47,6 @@ tauri-plugin-process = "2"
 tauri-plugin-single-instance = { version = "2.4.2", features = ["semver"] }
 # 只读解析 cc-switch.db；复用 tauri-plugin-sql 依赖树中既有的 sqlx/libsqlite3-sys，无新增原生依赖
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite"] }
-# git 仓库查询（静默读取分支，避免文件 I/O 触发安全软件弹窗）
-git2 = "0.19"
 # 文件系统监听 + 去抖：fs-watcher 替代 Git 变更面板的定时轮询
 notify = "6"
 notify-debouncer-mini = "0.4"
@@ -56,6 +54,14 @@ fontdb = "0.23"
 tauri-plugin-clipboard-manager = "2"
 sysinfo = "0.39.5"
 local-ip-address = "0.6.13"
+
+# macOS universal 交叉编译时不能复用宿主架构的 OpenSSL，因此仅在 macOS 使用 vendored 构建。
+[target.'cfg(target_os = "macos")'.dependencies]
+git2 = { version = "0.19", features = ["vendored-libgit2", "vendored-openssl"] }
+
+# 其他平台保持系统原生依赖解析，避免增加 Windows 构建工具要求和编译耗时。
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+git2 = "0.19"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Graphics_Gdi", "Win32_Storage_FileSystem", "Win32_System_Performance", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging", "Win32_System_JobObjects", "Win32_System_Threading"] }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,6 +7,7 @@
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://127.0.0.1:1420",
     "beforeBuildCommand": "npm run build",
+    "beforeBundleCommand": "node ./scripts/prepare-bundle-binaries.mjs",
     "frontendDist": "../dist"
   },
   "app": {


### PR DESCRIPTION
1.  添加打包前执行的二进制准备脚本
2.  调整git2依赖：仅macOS平台启用vendored构建来解决通用编译问题，其他平台保持原生依赖
3.  新增openssl-src依赖适配macOS编译需求