### PR TITLE
fix(terminal): suppress broad OSC 8 hyperlinks in full-screen TUIs

### DIFF
--- a/src/components/XTermTerminal.tsx
+++ b/src/components/XTermTerminal.tsx
@@ -1115,18 +1115,16 @@ export function XTermTerminal({ sessionId, isActive = true, isVisible = true, fo
       // even though WebGL is disabled while a background image is active.
       allowTransparency: true,
       theme: withVisibleSelectionTheme(isTransparentRef.current ? applyTransparency(baseTheme, background.overlayDarken) : baseTheme, false),
-      // OSC 8 超链接（codex 等 CLI 输出）默认点击行为是 window.open，在 Tauri
-      // webview 里会被拦成"是否导航"确认框。接管为系统默认浏览器打开，仅放行
-      // http/https，避免恶意 scheme。
-      linkHandler: {
-        activate: (_event, uri) => openHttpUrl(sessionId, uri),
-      },
     });
     const baseDisposables: TerminalSubsystemDisposable[] = [];
     const displayDisposables: TerminalSubsystemDisposable[] = [];
     const inputDisposables: TerminalSubsystemDisposable[] = [];
     // Keep Claude Code / other TUIs from overriding the app-wide thin cursor via DECSCUSR.
     baseDisposables.push(terminal.parser.registerCsiHandler({ intermediates: " ", final: "q" }, () => true));
+    // Some full-screen TUIs can tag a broad redraw region with one repository
+    // OSC 8 URI, making unrelated rows look clickable and open the same URL.
+    // Consume OSC 8 metadata while keeping visible URL and file link providers.
+    baseDisposables.push(terminal.parser.registerOscHandler(8, () => true));
 
     const fitAddon = new FitAddon();
     const imageAddon = new ImageAddon({


### PR DESCRIPTION
## 问题现象

在一台 Windows 电脑的 CLI-Manager 内置终端中，从带 GitHub remote 的仓库启动 Codex TUI 后，终端大量普通行都出现了链接虚线；点击任意这些行都会打开当前项目仓库 URL。

同一账号在另一台家用电脑上没有复现，因此这更像是依赖 Codex 版本、TUI 重绘时序、会话状态或具体 OSC 8 输出范围的低频兼容性案例，而不是所有环境都稳定发生的问题。

## 原因分析

CLI-Manager 当前同时支持两类链接：

1. xterm 原生 OSC 8 超链接，通过 `TerminalOptions.linkHandler` 打开；
2. `WebLinksAddon` 对终端中可见的 `http/https` 文本进行识别。

本次整行链接不是普通 URL 文本识别导致的。全屏 TUI 在一次重绘区域中携带同一个仓库 OSC 8 URI 时，xterm 会把该范围内的终端单元格都关联到同一个地址，所以无关行也会显示为链接并打开同一仓库。

## 修改内容

- 移除 xterm 原生 OSC 8 的激活 handler；
- 注册 `registerOscHandler(8, () => true)`，消费 OSC 8 元数据，但保留可见文本；
- 保留 `WebLinksAddon`，普通可见 URL 仍然可以点击；
- 保留现有文件路径 link provider。

因此修改只关闭终端程序通过不可见 OSC 8 元数据附加的链接，不影响终端中直接打印出来的 URL 和文件路径。

## 确定性复现

实际 Codex 场景并非每台机器都能复现，但可以在旧实现的内置 PowerShell 终端中确定性触发：

```powershell
$esc = [char]27
$bel = [char]7

[Console]::Write("${esc}]8;;https://github.com/example/repo${bel}")
1..8 | ForEach-Object { [Console]::WriteLine("OSC 8 link row $_") }
[Console]::Write("${esc}]8;;${bel}")
```

修改前，这些行共享同一个可点击地址；修改后只显示普通文本。

## 验证

- `npm run build` 通过；
- 浏览器级 xterm 回归：
  - OSC 8 行点击后没有 URI 激活，鼠标保持文本光标；
  - 普通可见 URL 仍由 `WebLinksAddon` 激活，鼠标显示 pointer；
- 补丁基于当前 `upstream/master`，只修改 `src/components/XTermTerminal.tsx`。

如果维护者更希望把 OSC 8 做成可配置选项，我也可以按项目偏好继续调整实现。