### PR TITLE
refactor(terminal): 调整终端尺寸计算的元素获取方式

### DIFF
--- a/src/hooks/useTerminalDisplay.ts
+++ b/src/hooks/useTerminalDisplay.ts
@@ -400,8 +400,9 @@ export function useTerminalDisplay({
     const resizeDisposable = terminal.onResize(({ cols, rows }) => {
       if (!forwardPtyResizeRef.current) return;
       if (cols < MIN_TERMINAL_COLS || rows < MIN_TERMINAL_ROWS) return;
-      const pixelWidth = terminal.dimensions?.css.canvas.width;
-      const pixelHeight = terminal.dimensions?.css.canvas.height;
+      const canvas = terminal.element?.querySelector("canvas");
+      const pixelWidth = canvas?.width;
+      const pixelHeight = canvas?.height;
       terminalProcessManager.resize(
         sessionId,
         cols,

--- a/src/terminal/browser/TerminalResizeRenderBarrier.ts
+++ b/src/terminal/browser/TerminalResizeRenderBarrier.ts
@@ -50,7 +50,7 @@ const createCanvasTerminalResizeFrame = (
   terminal: Terminal,
   container: HTMLElement,
 ): TerminalResizeFrame | null => {
-  const screen = terminal.screenElement;
+  const screen = terminal.element;
   if (!screen) return null;
   const canvases = [...screen.querySelectorAll("canvas")];
   if (canvases.length === 0) return null;


### PR DESCRIPTION
将原通过terminal.screenElement获取屏幕元素的方式，改为通过terminal.element查询canvas元素，适配最新的终端DOM结构变化