### PR TITLE
fix(terminal): 修复背景图启用后终端内容消失

### DIFF
--- a/scripts/terminalBackgroundLayout.test.mjs
+++ b/scripts/terminalBackgroundLayout.test.mjs
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const componentSource = readFileSync(
+  new URL("../src/components/XTermTerminal.tsx", import.meta.url),
+  "utf8",
+);
+const stylesSource = readFileSync(
+  new URL("../src/styles/components.css", import.meta.url),
+  "utf8",
+);
+
+test("terminal content remains a full-size positioned layer", () => {
+  assert.match(
+    componentSource,
+    /<div className="absolute inset-0 overflow-hidden">\s*<div[\s\S]*?ref=\{containerRef\}/,
+  );
+});
+
+test("background stacking does not override terminal child positioning", () => {
+  const stackingRule = stylesSource.match(
+    /\.ui-terminal-bg-layer\[data-bg-enabled="true"\]\s*>\s*\*\s*\{([^}]*)\}/,
+  );
+
+  assert.ok(stackingRule, "expected the terminal background stacking rule");
+  assert.match(stackingRule[1], /z-index:\s*2\s*;/);
+  assert.doesNotMatch(stackingRule[1], /\bposition\s*:/);
+});

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -7478,9 +7478,9 @@
   transition: background-color 300ms ease;
 }
 
-/* Keep the xterm container above the pseudo-element layers. */
+/* Keep terminal content and controls above the pseudo-element layers without
+   overriding their own absolute/relative positioning. */
 .ui-terminal-bg-layer[data-bg-enabled="true"] > * {
-  position: relative;
   z-index: 2;
 }
 


### PR DESCRIPTION
## 问题

启用终端背景图后，终端内容区域会坍缩，界面只剩背景图可见。该回归由 Markdown 预览引入的新全尺寸绝对定位容器触发。

## 根因

背景图 stacking 规则对 `.ui-terminal-bg-layer` 的所有直接子元素强制设置了 `position: relative`。这会覆盖终端主内容层的 `position: absolute; inset: 0`，导致其失去全尺寸定位并坍缩，而背景伪元素仍正常铺满容器。

## 修复

- 背景图规则仅保留 `z-index`，不再覆盖子元素自身的定位方式
- 增加布局契约测试，确保终端主层保持全尺寸绝对定位，且背景规则不会再次声明 `position`

## 验证

- `node --test scripts/terminalBackgroundLayout.test.mjs`
- `./node_modules/.bin/tsc.cmd --noEmit`
- `npm run build`
- GitNexus staged change detection: low risk, 0 affected processes