### PR TITLE
fix: bound hook snapshot memory usage

### DIFF
--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -2,6 +2,7 @@ use git2::{build::CheckoutBuilder, DiffOptions, Repository, ResetType, StatusOpt
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::Path;
+use std::sync::{Mutex, OnceLock};
 use tauri::{AppHandle, State};
 
 pub use super::git_diff::{GitDiffOptions, GitFileDiffPayload};
@@ -10,9 +11,19 @@ use crate::shell_resolver::silent_command;
 
 const GIT_DIFF_LINE_STATS_STATUS_LIMIT: usize = 500;
 const GIT_DIFF_LINE_STATS_LINE_LIMIT: usize = 200_000;
-const OOM_PATCH_WARN_BYTES: usize = 1024 * 1024;
-const OOM_SNAPSHOT_PATCH_RETURN_MAX_BYTES: usize = 1024 * 1024;
+const MAX_WORKTREE_PATCH_BYTES: usize = 4 * 1024 * 1024;
+const OOM_PATCH_WARN_BYTES: usize = MAX_WORKTREE_PATCH_BYTES;
+const OOM_SNAPSHOT_PATCH_RETURN_MAX_BYTES: usize = MAX_WORKTREE_PATCH_BYTES;
 const OOM_SNAPSHOT_FILES_WARN_COUNT: usize = 500;
+
+static WORKTREE_OPERATION_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn acquire_worktree_operation_lock() -> Result<std::sync::MutexGuard<'static, ()>, String> {
+    WORKTREE_OPERATION_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .map_err(|_| "worktree_operation_lock_poisoned".to_string())
+}
 
 fn log_worktree_snapshot_oom_diagnostic(
     phase: &str,
@@ -778,7 +789,14 @@ fn collect_git_changes_from_repo(repo: &Repository) -> Result<Vec<GitFileChange>
     Ok(changes)
 }
 
-fn build_worktree_patch(repo: &Repository) -> Result<String, String> {
+#[derive(Debug)]
+struct BoundedPatch {
+    text: String,
+    bytes: usize,
+    truncated: bool,
+}
+
+fn build_worktree_patch(repo: &Repository) -> Result<BoundedPatch, String> {
     let head_tree = repo
         .head()
         .and_then(|head| head.peel_to_tree())
@@ -789,30 +807,30 @@ fn build_worktree_patch(repo: &Repository) -> Result<String, String> {
         .include_untracked(true)
         .recurse_untracked_dirs(true)
         .show_untracked_content(true)
-        .show_binary(true)
+        .show_binary(false)
+        .max_size(MAX_WORKTREE_PATCH_BYTES as i64)
         .context_lines(3);
 
     let diff = repo
         .diff_tree_to_workdir_with_index(Some(&head_tree), Some(&mut diff_opts))
         .map_err(|e| format!("snapshot_diff_failed: {e}"))?;
-    format_diff_to_text_allow_empty(&diff)
+    format_diff_to_bounded_text(&diff, MAX_WORKTREE_PATCH_BYTES)
 }
 
 fn build_worktree_snapshot(
     project_path: &str,
     repo: &Repository,
 ) -> Result<GitWorktreeSnapshot, String> {
-    let patch = build_worktree_patch(repo)?;
-    let patch_bytes = patch.len();
     let files = collect_git_changes_from_repo(repo)?;
+    let patch = build_worktree_patch(repo)?;
     Ok(GitWorktreeSnapshot {
         project_path: project_path.to_string(),
         head: repo_head_oid(repo)?,
         branch: repo_branch_name(repo),
-        dirty: !patch.trim().is_empty() || !files.is_empty(),
-        patch,
-        patch_bytes,
-        patch_truncated: false,
+        dirty: patch.truncated || !patch.text.trim().is_empty() || !files.is_empty(),
+        patch: patch.text,
+        patch_bytes: patch.bytes,
+        patch_truncated: patch.truncated,
         files,
     })
 }
@@ -821,7 +839,8 @@ fn truncate_snapshot_patch_for_webview(snapshot: &mut GitWorktreeSnapshot) {
     if snapshot.patch.len() <= OOM_SNAPSHOT_PATCH_RETURN_MAX_BYTES {
         return;
     }
-    snapshot.patch.clear();
+    // Assignment drops the oversized allocation; String::clear() would retain its capacity.
+    snapshot.patch = String::new();
     snapshot.patch_truncated = true;
 }
 
@@ -993,6 +1012,7 @@ pub async fn git_get_worktree_snapshot(
     log::debug!("[git_get_worktree_snapshot] project_path: {}", project_path);
 
     tokio::task::spawn_blocking(move || {
+        let _worktree_lock = acquire_worktree_operation_lock()?;
         let started_at = std::time::Instant::now();
         let effective_project_path = effective_git_project_path(&project_path);
         let path = Path::new(&effective_project_path);
@@ -1086,6 +1106,7 @@ pub async fn git_restore_worktree_snapshot(
     );
 
     tokio::task::spawn_blocking(move || {
+        let _worktree_lock = acquire_worktree_operation_lock()?;
         let effective_project_path = effective_git_project_path(&project_path);
         let path = Path::new(&effective_project_path);
         if !crate::wsl::is_wsl_config_dir(&project_path) && !path.exists() {
@@ -1098,7 +1119,10 @@ pub async fn git_restore_worktree_snapshot(
         }
 
         let current_patch = build_worktree_patch(&repo)?;
-        if current_patch != expected_current_patch {
+        if current_patch.truncated {
+            return Err("worktree_snapshot_too_large".to_string());
+        }
+        if current_patch.text != expected_current_patch {
             return Err("worktree_changed_since_snapshot".to_string());
         }
 
@@ -1148,6 +1172,7 @@ pub async fn git_fork_worktree_snapshot(
     validate_snapshot_branch_name(&branch_name)?;
 
     tokio::task::spawn_blocking(move || {
+        let _worktree_lock = acquire_worktree_operation_lock()?;
         let effective_project_path = effective_git_project_path(&project_path);
         let path = Path::new(&effective_project_path);
         if !crate::wsl::is_wsl_config_dir(&project_path) && !path.exists() {
@@ -1160,7 +1185,10 @@ pub async fn git_fork_worktree_snapshot(
         }
 
         let current_patch = build_worktree_patch(&repo)?;
-        if current_patch != expected_current_patch {
+        if current_patch.truncated {
+            return Err("worktree_snapshot_too_large".to_string());
+        }
+        if current_patch.text != expected_current_patch {
             return Err("worktree_changed_since_snapshot".to_string());
         }
 
@@ -1213,6 +1241,50 @@ pub(super) fn format_diff_to_text_allow_empty(diff: &git2::Diff) -> Result<Strin
     .map_err(|e| format!("打印 diff 失败: {}", e))?;
 
     Ok(patch_text)
+}
+
+fn format_diff_to_bounded_text(
+    diff: &git2::Diff,
+    max_bytes: usize,
+) -> Result<BoundedPatch, String> {
+    let mut patch_text = String::new();
+    let mut patch_bytes = 0usize;
+    let mut truncated = false;
+
+    let result = diff.print(git2::DiffFormat::Patch, |_delta, _hunk, line| {
+        if line.origin() == 'B' {
+            truncated = true;
+            return false;
+        }
+        let prefix_bytes = usize::from(matches!(line.origin(), '+' | '-' | ' '));
+        let line_bytes = prefix_bytes.saturating_add(line.content().len());
+        patch_bytes = patch_bytes.saturating_add(line_bytes);
+        if patch_text.len().saturating_add(line_bytes) > max_bytes {
+            truncated = true;
+            return false;
+        }
+        match line.origin() {
+            '+' | '-' | ' ' => patch_text.push(line.origin()),
+            _ => {}
+        }
+        patch_text.push_str(std::str::from_utf8(line.content()).unwrap_or(""));
+        true
+    });
+
+    if let Err(err) = result {
+        if !truncated {
+            return Err(format!("打印受限 diff 失败: {}", err));
+        }
+    }
+    if truncated {
+        patch_text = String::new();
+    }
+
+    Ok(BoundedPatch {
+        text: patch_text,
+        bytes: patch_bytes,
+        truncated,
+    })
 }
 
 /// 校验前端传入的 repo 相对路径（前端不可信，防越界）。
@@ -2557,7 +2629,7 @@ mod tests {
         is_nested_repo_entry, is_no_stash_created, parse_wsl_git_status, parse_wsl_numstat,
         remove_untracked_snapshot_file, scan_git_repository_paths, should_skip_diff_line_stats,
         validate_branch_name, validate_repo_relative_path, validate_snapshot_branch_name,
-        GIT_DIFF_LINE_STATS_STATUS_LIMIT,
+        GIT_DIFF_LINE_STATS_STATUS_LIMIT, MAX_WORKTREE_PATCH_BYTES,
     };
     use git2::{IndexAddOption, Repository, Signature};
     use std::fs;
@@ -2743,6 +2815,25 @@ mod tests {
 
         assert!(paths.contains(&"untracked.txt"));
         assert!(!paths.iter().any(|p| p.starts_with("sub-repo-a")));
+    }
+
+    #[test]
+    fn worktree_snapshot_bounds_large_untracked_patch() {
+        let (_temp, repo_path) = init_temp_repo();
+        let large_file = Path::new(&repo_path).join("large.txt");
+        fs::write(
+            &large_file,
+            vec![b'x'; MAX_WORKTREE_PATCH_BYTES.saturating_add(1024)],
+        )
+        .unwrap();
+
+        let repo = Repository::open(&repo_path).unwrap();
+        let snapshot = build_worktree_snapshot(&repo_path, &repo).unwrap();
+
+        assert!(snapshot.patch_truncated);
+        assert!(snapshot.patch.is_empty());
+        assert!(snapshot.dirty);
+        assert!(snapshot.files.iter().any(|file| file.path == "large.txt"));
     }
 
     #[test]

--- a/src/stores/replayStore.ts
+++ b/src/stores/replayStore.ts
@@ -122,6 +122,19 @@ const OOM_REPLAY_EVENTS_WARN_COUNT = 200;
 const REPLAY_EVENTS_IN_MEMORY_LIMIT = 200;
 const SNAPSHOT_PATCH_DIR = "replay-snapshots";
 const SNAPSHOT_PATCH_STORAGE = "file";
+const SNAPSHOT_CAPTURE_DEBOUNCE_MS = 750;
+
+interface SnapshotCaptureRequest {
+  sessionKey: string;
+  projectPath: string;
+  reason?: string;
+}
+
+type SnapshotCaptureRunner = (request: SnapshotCaptureRequest) => Promise<ReplayEvent | null>;
+
+const inFlightSnapshotCaptures = new Map<string, Promise<ReplayEvent | null>>();
+const pendingAutomaticSnapshotRequests = new Map<string, SnapshotCaptureRequest>();
+const automaticSnapshotTimers = new Map<string, number>();
 
 function stringByteLength(value: string): number {
   if (typeof Blob !== "undefined") return new Blob([value]).size;
@@ -171,6 +184,45 @@ function normalizeTimestamp(value: string | null | undefined): string {
 function trimOptional(value: string | null | undefined): string | null {
   const trimmed = value?.trim();
   return trimmed ? trimmed : null;
+}
+
+function snapshotProjectKey(projectPath: string): string {
+  const normalized = projectPath.trim().replace(/\\/g, "/").replace(/\/+$/, "");
+  return /^[a-z]:\//i.test(normalized) ? normalized.toLowerCase() : normalized;
+}
+
+function isExternalHookSession(sessionKey: string): boolean {
+  return sessionKey.trim().startsWith("external:");
+}
+
+function armAutomaticSnapshot(key: string, capture: SnapshotCaptureRunner): void {
+  const existingTimer = automaticSnapshotTimers.get(key);
+  if (existingTimer !== undefined) window.clearTimeout(existingTimer);
+
+  const timer = window.setTimeout(() => {
+    automaticSnapshotTimers.delete(key);
+    const activeCapture = inFlightSnapshotCaptures.get(key);
+    if (activeCapture) {
+      void activeCapture.finally(() => {
+        if (pendingAutomaticSnapshotRequests.has(key)) armAutomaticSnapshot(key, capture);
+      }).catch(() => {});
+      return;
+    }
+
+    const request = pendingAutomaticSnapshotRequests.get(key);
+    if (!request) return;
+    pendingAutomaticSnapshotRequests.delete(key);
+    void capture(request).finally(() => {
+      if (pendingAutomaticSnapshotRequests.has(key)) armAutomaticSnapshot(key, capture);
+    }).catch(() => {});
+  }, SNAPSHOT_CAPTURE_DEBOUNCE_MS);
+  automaticSnapshotTimers.set(key, timer);
+}
+
+function scheduleAutomaticSnapshot(request: SnapshotCaptureRequest, capture: SnapshotCaptureRunner): void {
+  const key = snapshotProjectKey(request.projectPath);
+  pendingAutomaticSnapshotRequests.set(key, request);
+  armAutomaticSnapshot(key, capture);
 }
 
 function parseJsonArray(value: string): string[] {
@@ -656,7 +708,8 @@ function applyPersistedEvent(session: ReplaySession, event: ReplayEvent) {
   }, events.length >= OOM_REPLAY_EVENTS_WARN_COUNT || patchStats.maxPatchBytes >= OOM_PATCH_WARN_BYTES);
 }
 
-function shouldCaptureSnapshot(event: CliHookEventName): boolean {
+function shouldCaptureSnapshot(event: CliHookEventName, sessionKey?: string): boolean {
+  if (sessionKey && isExternalHookSession(sessionKey)) return false;
   return event === "UserPromptSubmit" ||
     event === "ToolStop" ||
     event === "AgentToolStop" ||
@@ -774,7 +827,7 @@ export const useReplayStore = create<ReplayStore>((set, get) => ({
         : trimOptional(payload.cwd) ?? existing?.projectPath ?? null;
       const rawPayload = payload as unknown as Record<string, unknown>;
       const rawPayloadBytes = stringByteLength(JSON.stringify(rawPayload));
-      const willCaptureSnapshot = Boolean(projectPath && shouldCaptureSnapshot(payload.event));
+      const willCaptureSnapshot = Boolean(projectPath && shouldCaptureSnapshot(payload.event, sessionKey));
       logReplayOomDiagnostic("recordCliHookEvent", {
         sessionKey,
         event: payload.event,
@@ -800,8 +853,11 @@ export const useReplayStore = create<ReplayStore>((set, get) => ({
       );
       applyPersistedEvent(session, event);
 
-      if (projectPath && shouldCaptureSnapshot(payload.event)) {
-        void get().captureCodeSnapshot(sessionKey, projectPath, payload.event);
+      if (projectPath && shouldCaptureSnapshot(payload.event, sessionKey)) {
+        scheduleAutomaticSnapshot(
+          { sessionKey, projectPath, reason: payload.event },
+          (request) => get().captureCodeSnapshot(request.sessionKey, request.projectPath, request.reason),
+        );
       }
     } catch (err) {
       logError("Failed to record AI replay hook event", { payload, err });
@@ -812,89 +868,110 @@ export const useReplayStore = create<ReplayStore>((set, get) => ({
   captureCodeSnapshot: async (sessionKey, projectPath, reason) => {
     const normalizedProjectPath = trimOptional(projectPath);
     if (!normalizedProjectPath) return null;
-    try {
-      await ensureTables();
-      const startedAt = performance.now();
-      const snapshot = await invoke<ReplayWorktreeSnapshot>("git_get_worktree_snapshot", {
-        projectPath: normalizedProjectPath,
-      });
-      const elapsedMs = Math.round(performance.now() - startedAt);
-      const patchBytes = snapshot.patchBytes ?? stringByteLength(snapshot.patch);
-      logReplayOomDiagnostic("captureCodeSnapshot.result", {
+    const key = snapshotProjectKey(normalizedProjectPath);
+    if (inFlightSnapshotCaptures.has(key)) {
+      logReplayOomDiagnostic("captureCodeSnapshot.coalesced", {
         sessionKey,
         projectPath: normalizedProjectPath,
         reason: reason ?? "manual",
-        dirty: snapshot.dirty,
-        files: snapshot.files.length,
-        patchBytes,
-        patchTruncated: Boolean(snapshot.patchTruncated),
-        elapsedMs,
-        thresholdExceeded: patchBytes >= OOM_PATCH_WARN_BYTES || Boolean(snapshot.patchTruncated),
-      }, patchBytes >= OOM_PATCH_WARN_BYTES || Boolean(snapshot.patchTruncated));
-      if (!snapshot.dirty) return null;
-      if (!snapshot.patch.trim() && !snapshot.patchTruncated) return null;
+      });
+      return null;
+    }
 
-      const lastSnapshot = await getLastSnapshotPayload(sessionKey);
-      if (!snapshot.patchTruncated && lastSnapshot?.patch === snapshot.patch && lastSnapshot?.head === snapshot.head) {
-        logReplayOomDiagnostic("captureCodeSnapshot.skippedDuplicate", {
+    const capturePromise = (async (): Promise<ReplayEvent | null> => {
+      try {
+        await ensureTables();
+        const startedAt = performance.now();
+        const snapshot = await invoke<ReplayWorktreeSnapshot>("git_get_worktree_snapshot", {
+          projectPath: normalizedProjectPath,
+        });
+        const elapsedMs = Math.round(performance.now() - startedAt);
+        const patchBytes = snapshot.patchBytes ?? stringByteLength(snapshot.patch);
+        logReplayOomDiagnostic("captureCodeSnapshot.result", {
           sessionKey,
           projectPath: normalizedProjectPath,
+          reason: reason ?? "manual",
+          dirty: snapshot.dirty,
+          files: snapshot.files.length,
           patchBytes,
-        }, patchBytes >= OOM_PATCH_WARN_BYTES);
+          patchTruncated: Boolean(snapshot.patchTruncated),
+          elapsedMs,
+          thresholdExceeded: patchBytes >= OOM_PATCH_WARN_BYTES || Boolean(snapshot.patchTruncated),
+        }, patchBytes >= OOM_PATCH_WARN_BYTES || Boolean(snapshot.patchTruncated));
+        if (!snapshot.dirty) return null;
+        if (!snapshot.patch.trim() && !snapshot.patchTruncated) return null;
+
+        const lastSnapshot = await getLastSnapshotPayload(sessionKey);
+        if (!snapshot.patchTruncated && lastSnapshot?.patch === snapshot.patch && lastSnapshot?.head === snapshot.head) {
+          logReplayOomDiagnostic("captureCodeSnapshot.skippedDuplicate", {
+            sessionKey,
+            projectPath: normalizedProjectPath,
+            patchBytes,
+          }, patchBytes >= OOM_PATCH_WARN_BYTES);
+          return null;
+        }
+
+        const existing = await fetchSession(sessionKey);
+        const title = existing?.title ?? `${snapshot.branch ?? "git"} replay`;
+        const timestamp = new Date().toISOString();
+        const detail = translateCurrent("aiReplay.snapshot.detail", {
+          count: snapshot.files.length,
+          branch: snapshot.branch ?? snapshot.head.slice(0, 7),
+        });
+        const checkpointId = `snapshot-${Date.now().toString(36)}`;
+        const payload: Record<string, unknown> = {
+          ...snapshot,
+          patchBytes,
+          checkpointId,
+          reason: reason ?? "manual",
+          changedFiles: snapshot.files.map((file) => file.path),
+        };
+        let persistedPayload = payload;
+        if (snapshot.patch.trim()) {
+          const patchPath = await writeSnapshotPatchFile(sessionKey, checkpointId, snapshot.patch);
+          persistedPayload = {
+            ...payload,
+            patchPath,
+            patchStorage: SNAPSHOT_PATCH_STORAGE,
+          };
+          delete persistedPayload.patch;
+        }
+        const { session, event } = await persistReplayEvent(
+          sessionKey,
+          {
+            title,
+            cliSessionId: existing?.cliSessionId ?? null,
+            source: existing?.source ?? null,
+            projectPath: normalizedProjectPath,
+          },
+          {
+            kind: "snapshot",
+            title: translateCurrent("aiReplay.snapshot.title"),
+            detail,
+            timestamp,
+            durationMs: null,
+            status: "saved",
+            tags: ["snapshot", "git", "rollback"],
+            payload,
+            persistedPayload,
+          }
+        );
+        applyPersistedEvent(session, event);
+        return event;
+      } catch (err) {
+        logError("Failed to capture AI replay code snapshot", { sessionKey, projectPath, err });
+        set({ error: String(err) });
         return null;
       }
+    })();
 
-      const existing = await fetchSession(sessionKey);
-      const title = existing?.title ?? `${snapshot.branch ?? "git"} replay`;
-      const timestamp = new Date().toISOString();
-      const detail = translateCurrent("aiReplay.snapshot.detail", {
-        count: snapshot.files.length,
-        branch: snapshot.branch ?? snapshot.head.slice(0, 7),
-      });
-      const checkpointId = `snapshot-${Date.now().toString(36)}`;
-      const payload: Record<string, unknown> = {
-        ...snapshot,
-        patchBytes,
-        checkpointId,
-        reason: reason ?? "manual",
-        changedFiles: snapshot.files.map((file) => file.path),
-      };
-      let persistedPayload = payload;
-      if (snapshot.patch.trim()) {
-        const patchPath = await writeSnapshotPatchFile(sessionKey, checkpointId, snapshot.patch);
-        persistedPayload = {
-          ...payload,
-          patchPath,
-          patchStorage: SNAPSHOT_PATCH_STORAGE,
-        };
-        delete persistedPayload.patch;
+    inFlightSnapshotCaptures.set(key, capturePromise);
+    try {
+      return await capturePromise;
+    } finally {
+      if (inFlightSnapshotCaptures.get(key) === capturePromise) {
+        inFlightSnapshotCaptures.delete(key);
       }
-      const { session, event } = await persistReplayEvent(
-        sessionKey,
-        {
-          title,
-          cliSessionId: existing?.cliSessionId ?? null,
-          source: existing?.source ?? null,
-          projectPath: normalizedProjectPath,
-        },
-        {
-          kind: "snapshot",
-          title: translateCurrent("aiReplay.snapshot.title"),
-          detail,
-          timestamp,
-          durationMs: null,
-          status: "saved",
-          tags: ["snapshot", "git", "rollback"],
-          payload,
-          persistedPayload,
-        }
-      );
-      applyPersistedEvent(session, event);
-      return event;
-    } catch (err) {
-      logError("Failed to capture AI replay code snapshot", { sessionKey, projectPath, err });
-      set({ error: String(err) });
-      return null;
     }
   },
 }));


### PR DESCRIPTION
## 概要

修复外部终端启动 Claude 后，CLI-Manager 接收 Hook 事件并自动创建 Git 快照时出现的内存峰值问题。

日志显示，大型仓库的一次工作区 diff 可能生成超过 1 GiB 的补丁内容。Rust、前端状态和数据库写入过程中会产生多份数据副本，最终造成进程内存快速增长，表现为任务完成后 CLI-Manager 内存不释放或接近 OOM。

## 根因

外部 Claude 的多个 Hook 事件会触发自动 Git 快照：

1. CLI-Manager 收到 `UserPromptSubmit`、`ToolStop`、`Stop` 等事件。
2. 每个事件都扫描整个 Git 工作区。
3. 未跟踪文件和二进制文件也会被加入 diff。
4. 大型仓库会生成巨大的补丁字符串。
5. 同一任务中的多个 Hook 可能同时触发多个快照请求。

原实现没有对 diff 生成过程设置足够的硬边界，因此大型仓库会产生非常高的瞬时内存峰值。

## 修改内容

### 1. 外部 Hook 不再自动创建 Git 快照

对于 `external:*` 会话：

- Hook 事件仍然正常写入回放记录。
- 会话状态、来源、项目路径和消息内容不受影响。
- 不再因为外部 Hook 自动扫描整个工作区并创建快照。
- 手动触发快照的接口仍然保留。

### 2. 限制本地自动快照频率

对于 CLI-Manager 内部会话：

- 自动快照增加 750ms 防抖。
- 同一项目路径短时间内的多个请求会合并。
- 同一项目已有快照执行时，新的请求不会并发重复执行。
- 项目路径会进行统一规范化，避免 Windows 路径大小写和分隔符造成重复任务。

这样可以避免一个任务中的连续 Hook 事件重复扫描同一个工作区。

### 3. 限制 Git diff 大小

Rust 后端对工作区快照增加 4 MiB 硬上限：

- 使用 libgit2 的 `max_size` 限制大文件读取。
- 禁用二进制补丁正文生成。
- 超过限制的 diff 会标记为 `patch_truncated`。
- 被截断的快照不再保留完整补丁正文。
- 截断后的字符串会释放原有的大容量内存。

4 MiB 是在可用性和内存安全之间的折中：

- 1 MiB 对正常的大型重构、锁文件和生成文件变更偏小。
- 完全不限制会重新引入大型仓库 OOM 风险。
- 4 MiB 足以覆盖大多数常规代码变更，同时能够限制最坏情况下的内存占用。

### 4. 防止不完整快照被用于恢复

对于被截断或包含二进制内容的快照：

- 快照仍可记录，用于说明工作区存在变更。
- 不允许使用该快照执行 Rollback。
- 不允许使用该快照执行 Fork。
- 后端会返回 `worktree_snapshot_too_large`，避免使用不完整 diff 破坏工作区。

### 5. 串行化工作区操作

Git 快照、恢复和 Fork 操作增加全局工作区操作锁：

- 防止快照和恢复同时操作同一个工作区。
- 防止多个 Git 操作互相覆盖或读取到不一致状态。
- 不同项目之间也会串行执行，极端情况下可能增加等待时间。

## 行为变化与影响

| 场景 | 行为变化 | 影响 |
| --- | --- | --- |
| 外部 Claude 会话 | 不再自动创建 Git 快照 | 外部会话的自动回滚检查点会减少，但 Hook 事件仍会记录 |
| 内部 CLI 会话 | 快照延迟 750ms，并合并短时间重复事件 | 快照数量减少，回滚检查点粒度不再是每个 Hook 一个 |
| 应用在防抖窗口内退出 | 延迟中的快照可能未执行 | 事件记录仍保留，但可能少一个快照 |
| 超过 4 MiB 的 diff | 快照被标记为截断 | 该快照不能用于 Rollback 或 Fork |
| 二进制文件变更 | 不保存二进制补丁正文 | 该快照不能用于 Rollback 或 Fork |
| 多个会话共用同一项目目录 | 共享一次快照任务 | 快照可能归属最后触发 Hook 的会话 |
| 并发 Git 操作 | 工作区操作串行化 | 可能增加少量等待时间，但避免状态竞争 |

## 不受影响的行为

- PTY 创建、写入、调整大小和关闭逻辑未修改。
- `XTermTerminal.tsx` 已恢复为仓库状态。
- Hook 事件本身仍会持久化。
- 小型普通文本 diff 的查看和回滚流程保持不变。
- 没有新增数据库迁移。
- 没有修改前端终端渲染逻辑。

## 验证结果

- `npx tsc --noEmit` 通过。
- `cargo check` 通过。
- `cargo fmt -- --check` 通过。
- `npm run build` 通过。
- `cargo test commands::git::tests`：36/36 通过。
- 新增大型未跟踪文件快照截断回归测试。
- Tauri 开发模式启动成功。
- 已收到真实外部 Claude Hook 事件，未再观察到外部 Hook 自动触发工作区快照。

完整 Rust 测试套件中仍有 11 个既有的 macOS、路径和共享环境相关失败，与本次改动无关。

## 评审重点

请重点确认以下产品行为是否符合预期：

1. 外部 Claude 会话不再自动生成回滚快照。
2. 超过 4 MiB 或包含二进制内容的快照不支持 Rollback/Fork。
3. 同一项目多个会话共享快照时，快照归属最后触发请求的会话。
4. 自动快照增加 750ms 延迟，并可能合并多个 Hook 事件。