### PR TITLE
fix(terminal): 修复 macOS 中文输入法下符号键首次单击无反应

### DIFF
--- a/src/hooks/useTerminalInput.ts
+++ b/src/hooks/useTerminalInput.ts
@@ -753,13 +753,21 @@ export function useTerminalInput({
     }: TerminalInputForwardingOptions,
   ): TerminalInputForwardingController => {
     let lastForwardedTerminalInput: { data: string; source: TerminalInputSource; at: number } | null = null;
-    const isImeDuplicateCandidate = (data: string) => {
+    const isImeDuplicateCandidate = (data: string, source: TerminalInputSource) => {
       if (!data || data === "\r" || data === "\x7f" || data === "\b" || data.startsWith("\x1b")) return false;
       const normalized = data.replace(/\r\n?/g, "\n");
-      return Boolean(normalized.trim()) && /[^\x00-\x7f]/.test(normalized);
+      if (!Boolean(normalized.trim())) return false;
+      // 跨源去重的目标：同一字符既被 IME 恢复（nativeTextInput）转发，又被 xterm 的
+      // onData 转发，导致双份。非 ASCII（中文/标点）一直是候选；ASCII 符号
+      // （如 Shift+1 的 ! 或 Shift+' 的 "）在 macOS 上也会走 IME 恢复路径，
+      // 因此来自 nativeTextInput 的单个可打印 ASCII 字符同样纳入候选。
+      if (/[^\x00-\x7f]/.test(normalized)) return true;
+      return source === "nativeTextInput"
+        && Array.from(normalized).length === 1
+        && normalized.charCodeAt(0) >= 32;
     };
     const shouldDropCrossSourceImeDuplicate = (data: string, source: TerminalInputSource, now: number) => {
-      if (!isImeDuplicateCandidate(data) || !lastForwardedTerminalInput) return false;
+      if (!isImeDuplicateCandidate(data, source) || !lastForwardedTerminalInput) return false;
       const deltaMs = now - lastForwardedTerminalInput.at;
       return (
         lastForwardedTerminalInput.source !== source

--- a/src/lib/terminalIme.ts
+++ b/src/lib/terminalIme.ts
@@ -19,6 +19,14 @@ const IME_PROCESS_KEY_RECOVERY_WINDOW_MS = 400;
 const IME_COMPOSITION_END_SUPPRESS_WINDOW_MS = 80;
 const NATIVE_TEXT_INPUT_DEDUP_WINDOW_MS = 16;
 const CJK_NATIVE_PUNCTUATION_PATTERN = /^[\u3000-\u303f\uff01-\uff0f\uff1a-\uff20\uff3b-\uff40\uff5b-\uff65]+$/u;
+// macOS 上经 IME 输入上下文提交的 ASCII 符号字符（需要 Shift 或本身就是符号的键）。
+// 这类字符在 WebKit 中可能以「insertText 先于 keydown(229)」的顺序到达，
+// 导致既有恢复逻辑（依赖 keydown(229)）无法触发。
+const ASCII_SYMBOL_PATTERN = /^[!-/:-@[-^`{-~"']$/u;
+// 中文输入法下经 IME 提交的全角标点/符号（U+2014-U+2027 破折号/省略号，
+// U+2018-U+201F 各类引号，如 “ ” ‘ ’ ——…）。它们不属于 ASCII，
+// 但同样以「insertText 先于 keydown(229)」到达，需要与 ASCII 符号一致地触发恢复。
+const FULLWIDTH_SYMBOL_PATTERN = /^[—-‧‘-‟]+$/u;
 
 interface TerminalCellSize {
   width: number;
@@ -234,6 +242,13 @@ export const attachTerminalIme = ({
     const isMac = osPlatformRef.current === "macos"
       || (osPlatformRef.current === "unknown" && navigator.platform.toLowerCase().includes("mac"));
     if (isMac && CJK_NATIVE_PUNCTUATION_PATTERN.test(event.data)) return true;
+    // macOS 上经 IME 输入上下文提交的 ASCII 符号（如 Shift+1 的 !、Shift+' 的 "）：
+    // WebKit 可能以「insertText 先于 keydown(229)」的顺序到达，此刻 lastImeProcessKeyAt
+    // 尚未设置，既有的 keydown(229) 依赖无法触发；直接对这些符号触发恢复，
+    // 避免 xterm 因 _keyDownSeen 抑制而丢失该字符（否则单击打不出符号）。
+    if (isMac && ASCII_SYMBOL_PATTERN.test(event.data)) return true;
+    // 中文全角标点（“ ” ‘ ’ —— …）同样经 IME 提交，与 ASCII 符号一致触发恢复。
+    if (isMac && FULLWIDTH_SYMBOL_PATTERN.test(event.data)) return true;
     return lastImeProcessKeyAt >= 0 && now - lastImeProcessKeyAt <= IME_PROCESS_KEY_RECOVERY_WINDOW_MS;
   };
   const scheduleNativeTextInputRecovery = (data: string) => {


### PR DESCRIPTION
## 问题
macOS 下使用中文输入法时，在终端（xterm）内运行 claude / codex CLI，
按 `Shift+"` 打出全角引号（“ ”）等符号，**首次单击无反应**（0 个
字符），后续再按才正常。英文输入法下无此问题。

## 根因（bug 点）
macOS WKWebView 在中文输入法下，符号键的 `insertText` 事件**先于**
`keydown(229)` 到达，导致两条输入路径同时失效：

1. **xterm 主路径被锁**：前一个 Shift keydown 设置 `_keyDownSeen`，
   xterm 的 `_inputEvent` 抑制该字符（不转发）。
2. **IME 恢复替补路径不启动**：`shouldRecoverNativeTextInput` 依赖
   `lastImeProcessKeyAt`（由 `keydown(229)` 设置）先到达才恢复，
   但此刻 keydown 还没来 → 恢复不触发。

两条路都失效 → 首次单击无反应。后续按键因 keydown(229) 时间戳
已记录而恢复成功，所以只有第一次丢。

另外，当恢复与 xterm 同时工作时，跨源去重 `isImeDuplicateCandidate`
只对非 ASCII 生效，ASCII 符号（如 `!` `"`）会双发。

## 修复
- `src/lib/terminalIme.ts`：新增 `ASCII_SYMBOL_PATTERN` 与
  `FULLWIDTH_SYMBOL_PATTERN`，符号键的 insertText **不依赖
  keydown(229)** 直接触发恢复，解决首次单击无反应。
- `src/hooks/useTerminalInput.ts`：跨源去重放宽到 `nativeTextInput`
  源的单个可打印 ASCII 字符，解决双发。

## 验证
- 中文输入法下 `Shift+数字` / `Shift+"` 首次可正常输入，不再丢字符。
- 英文输入法下无回归。
- `tsc --noEmit` 通过。

## 环境
- macOS，CLI-Manager v1.3.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)