### PR TITLE
fix(terminal): alt+左右在分屏布局下可跨 pane 切换标签

### DIFF
--- a/src/stores/terminalPaneTree.ts
+++ b/src/stores/terminalPaneTree.ts
@@ -405,7 +405,23 @@ export function getNextSessionIdForShortcut(tree: TerminalPaneNode | null, activ
 
   if (activePane && activePane.sessionIds.length > 1) {
     const index = Math.max(0, activePane.sessionIds.indexOf(activeSessionId ?? activePane.activeSessionId ?? activePane.sessionIds[0]));
-    return activePane.sessionIds[(index + delta + activePane.sessionIds.length) % activePane.sessionIds.length];
+    const nextIndex = index + delta;
+
+    // 当前 pane 内仍有相邻 tab：正常切换（最常见路径）
+    if (nextIndex >= 0 && nextIndex < activePane.sessionIds.length) {
+      return activePane.sessionIds[nextIndex];
+    }
+
+    // 仅一个 pane（未分屏）：保持原有"循环 tab"行为不变，避免回归
+    if (leaves.length === 1) {
+      return activePane.sessionIds[(nextIndex + activePane.sessionIds.length) % activePane.sessionIds.length];
+    }
+
+    // 多 pane（分屏布局）：到达当前 pane 边界后溢出到相邻 pane，
+    // 而不是绕回当前 pane 开头 —— 否则 alt+左右永远切不出当前分屏窗口。
+    const paneIndex = leaves.findIndex((pane) => pane.id === activePane.id);
+    const nextPane = leaves[(paneIndex + delta + leaves.length) % leaves.length];
+    return nextPane.activeSessionId ?? nextPane.sessionIds[0] ?? null;
   }
 
   const paneIndex = Math.max(0, activePane ? leaves.findIndex((pane) => pane.id === activePane.id) : 0);


### PR DESCRIPTION
## 问题描述

在 workspan 分屏布局（多 pane）下，`alt+左右方向键`（默认绑定 `nextTab` / `prevTab`）无法切换到其他分屏窗口的标签。

只要当前 pane 内有 **2 个及以上** tab，快捷键就会永远在该 pane 内的 tab 间循环，无法切出当前分屏窗口 —— 用户被"困"在同一个 pane 里，必须用鼠标点别的 pane 才能切换。

## 复现步骤

1. 开启 workspan 模式，新建一个终端（pane A）
2. 在 pane A 内再新建一个 tab（共 2 个 tab）
3. 右键 → 分屏，得到第二个 pane（pane B，含 1 个 tab）
4. 切到 pane A 的某个 tab，按 `alt+右`
5. 实际：只在 pane A 的两个 tab 之间来回切换，永远到不了 pane B

## 根因

`getNextSessionIdForShortcut`（`src/stores/terminalPaneTree.ts`）：

```ts
if (activePane && activePane.sessionIds.length > 1) {
  const index = ...;
  // 永远在当前 pane 内取模循环，没有任何出口
  return activePane.sessionIds[(index + delta + activePane.sessionIds.length) % activePane.sessionIds.length];
}
```

只要当前 pane 有多个 tab，就无条件在 pane 内取模循环，后续"跨 pane"逻辑完全不可达。

## 修复方案

- pane 内相邻 tab 仍正常切换（最常见路径，行为不变）
- 到达当前 pane 边界时：
  - **未分屏（单 pane）**：保持原有"循环 tab"行为，**零回归**
  - **分屏布局（多 pane）**：溢出到相邻 pane，切出当前分屏窗口

行为对照（pane A=[s1,s2]、pane B=[s3]，激活 s2）：

| 操作 | 修复前 | 修复后 |
|------|--------|--------|
| s2 按 `alt+右` | s1（绕回 A 开头） | **s3（溢出到 B）** |
| s1 按 `alt+左` | s2（绕回 A 末尾） | **s3（溢出到 B）** |
| 单 pane 内任意切换 | 循环 tab | 循环 tab（不变） |

关联 [Issue #139](https://github.com/dark-hxx/CLI-Manager/issues/139)：作者此前已确认 alt+方向键切换异常并承诺修复，但分屏场景下至今仍存在。

## 测试

- 单 pane 多 tab：循环切换行为不变（脚本验证新旧一致）
- 多 pane：pane 内切换 + 边界溢出到相邻 pane（脚本验证）
- 从相邻 pane 切回时回到该 pane 当前激活的 tab，符合直觉
