### PR TITLE
修复：多会话持续输出时切换 Tab 卡死

### DIFF
--- a/.trellis/tasks/08-06-fix-terminal-tab-switch-output-freeze/design.md
+++ b/.trellis/tasks/08-06-fix-terminal-tab-switch-output-freeze/design.md
@@ -1,0 +1,96 @@
+# 多会话持续输出时切换 Tab 卡死：修复设计
+
+## 背景
+
+CLI-Manager 同时打开多个聊天会话时，如果其中一个会话正在持续输出，切换到另一个会话 Tab 可能使整个 App 长时间无响应。该问题在 Claude/Codex 等高频刷新终端界面中更容易出现。
+
+这里的“会话”指 Manager 中的聊天终端会话，不是绘画窗口，也不是窗口大小变化导致的滚动问题。
+
+## 根因
+
+这是前端 WebView 主线程的输出调度缺陷，不是用户操作不当，也不是会话游标不一致。
+
+1. `TerminalTabs` 保持所有会话的 `XTermTerminal` 挂载，隐藏 Tab 只设置 `display: none`；这是为了保留 xterm buffer 和 PTY 输出连续性。
+2. `useTerminalDisplay.flushPendingWrites()` 会把当前所有连续 live frame 无上限合并为一个字符串，再交给一次 `terminal.write()`。持续输出时，这个字符串可以不断变大。
+3. xterm.js 的内部时间片只在不同 write buffer 项之间让出主线程；一个超大 `terminal.write()` 仍可能在单次解析中长时间占用主线程。
+4. 每个会话都有独立的动画帧队列；写入完成后，`XTermTerminal` 还会执行 TUI 颜色/背景扫描并重新排帧。隐藏会话也会执行这些后处理。
+5. 多会话叠加后，React 的 Tab 切换、布局和输入事件得不到及时调度，表现为 App 卡死。
+
+PTY ACK 仍必须等待 xterm `write` callback，不能提前 ACK；隐藏会话也不能停止解析或丢弃输出，否则会破坏 daemon 背压、Replay 和重连语义。
+
+## 目标
+
+- 持续输出会话存在时，切换其他会话 Tab 保持响应。
+- 限制单次 xterm 解析任务的大小，并在批次之间让出主线程。
+- 隐藏会话继续维护完整 xterm buffer，不丢失、不重复、不乱序。
+- 保持 Replay、Reset、断线重连、ACK 和 daemon 背压契约不变。
+- 会话重新可见时，TUI 颜色和背景显示正确。
+
+## 非目标
+
+- 不暂停隐藏会话的 xterm 解析。
+- 不提前发送 PTY ACK。
+- 不修改 daemon 协议、PTY 边界、ConPTY 或 xterm 版本。
+- 不引入跨所有终端的全局调度器；先用局部有界调度解决已确认的无界批处理根因。
+
+## 方案
+
+### 1. Live 输出有界批处理
+
+在 `useTerminalDisplay` 的 live 输出队列中增加批次预算，按完整 PTY frame 边界合并，目标预算约为 `64 KiB` 原始输出字节。达到预算后立即结束当前批次，不再继续清空队列。
+
+单个 frame 即使超过预算也独立处理，避免在前端再次切割 daemon 已保证 ANSI/UTF-8 安全的 frame。每次 `terminal.write()` callback 完成后，按原有顺序提交该批次 frame 的 ACK，再通过下一动画帧继续处理剩余队列。
+
+Replay 和 Reset 仍然是批处理屏障：它们不会与普通 live frame 合并，且保持现有尺寸恢复和提交顺序。
+
+### 2. 隐藏会话降低 TUI 后处理优先级
+
+隐藏会话仍然写入 xterm 并维护 buffer，但不在每次写入或 xterm render/scroll 事件后执行 TUI 颜色扫描。会话切换为可见时，沿用可见性恢复 effect 做一次同步和刷新。
+
+这样不会改变隐藏会话的内容，只减少不可见状态下的重复 cell 扫描；可见会话仍保持当前颜色修正行为。
+
+### 3. 保持输出契约
+
+- 每个 frame 继续通过现有 `TerminalOutputDelivery.commit()` 提交。
+- 只有 xterm write callback 完成后才 ACK。
+- 队列仍按 sequence/FIFO 顺序消费。
+- worktree、分屏、历史会话重挂载继续由 `TerminalProcessManager` 保留未提交 frame。
+
+## 数据流
+
+```text
+PTY daemon output frame
+  -> PtyHostSocket / TerminalProcessManager
+  -> useTerminalDisplay pending queue
+  -> bounded live batch (frame boundary, 64 KiB target)
+  -> xterm.write(batch)
+  -> write callback
+  -> commit frames + ordered ACK
+  -> next animation frame / hidden low-priority turn
+```
+
+## 场景矩阵
+
+| 场景 | 预期行为 |
+|---|---|
+| 单会话持续输出 | 维持现有输出顺序和吞吐，不出现无界单次 write |
+| 多会话，仅一个会话输出 | 输出会话继续解析，切换 Tab 可及时响应 |
+| 多会话同时输出 | 各会话批次有界，不因单个会话清空全部队列而阻塞 UI |
+| 普通 shell / Claude / Codex TUI | 均保持完整输出；TUI 颜色在可见时正确 |
+| 前台 Tab / 后台 Tab | 前台正常后处理；后台保留 buffer 并降低 TUI 扫描 |
+| 分屏 / Workspan / 历史会话重挂载 | 未提交 frame 不丢失，新 Display 可继续接管 |
+| Replay / Reset / 断线重连 | 保持屏障、尺寸恢复、ACK 和 sequence 语义 |
+| UTF-8 / ANSI 边界 | 不在 daemon frame 内切割，不产生乱码或控制序列污染 |
+
+## 验证策略
+
+先添加失败测试证明现状会把连续 live frame 无界合并；再实现最小有界批处理并验证：
+
+- 每批不超过目标预算（单个超预算 frame 除外）。
+- 多批按顺序 write，前一批 callback 前不启动下一批。
+- 每个 frame 只提交和 ACK 一次，顺序不变。
+- Replay、Reset 和 live 输出屏障不变。
+- 隐藏会话跳过 TUI 后处理，可见时补做一次同步。
+
+静态验证包括 `npx tsc --noEmit`、`npm run build`、`git diff --check`；手动验证包括多会话高频输出、Tab/分屏/Workspan 切换和断线重连。
+

--- a/.trellis/tasks/08-06-fix-terminal-tab-switch-output-freeze/pr-body.md
+++ b/.trellis/tasks/08-06-fix-terminal-tab-switch-output-freeze/pr-body.md
@@ -1,0 +1,28 @@
+## 问题现象
+
+当多个聊天会话同时打开，其中一个会话持续输出时切换 Tab，WebView 主线程可能被长时间占用，表现为整个 App 卡死。隐藏会话仍保持挂载，持续输出期间还会触发终端 TUI 颜色/背景扫描，进一步放大阻塞。
+
+## 根因
+
+前端输出队列会在一次动画帧中无界合并连续 live PTY frame，最终调用一次超大的 `terminal.write()`。xterm 在写入过程中执行解析和渲染，隐藏会话的 TUI 颜色/背景扫描也同步运行，导致 Tab 切换、React 渲染和输入事件无法及时得到主线程调度。
+
+## 修改内容
+
+1. 为连续 live 输出增加 64 KiB 原始 frame 字节预算，只在完整 PTY frame 边界合并；超预算 frame 独立写入，后续批次等待当前 xterm `write` callback 和下一动画帧。
+2. 隐藏会话继续写入 xterm 并保留完整 buffer，但跳过 TUI 颜色/背景扫描；切回可见时由现有可见性 effect 补做一次同步。
+
+Replay/Reset 屏障、PTY frame 边界、xterm `write` callback 后的 `TerminalOutputDelivery.commit()`/ACK 时序均保持不变；未修改 daemon、ConPTY、xterm 版本或依赖。
+
+## 验证
+
+- `terminalReplay.test.mjs`：13/13 通过。
+- `terminalTuiColorSync.test.mjs`、`terminalVisibility.test.mjs` 及相关终端测试：19/19 通过。
+- `npx tsc --noEmit`：通过。
+- `npm run build`：通过。
+- `git diff --check`：通过。
+
+全量 `scripts/*.test.mjs` 还存在 3 项与本次改动无关的基线/环境失败：缺少 `cargo` 的 Codex proxy E2E、旧版 SSH agent 版本断言，以及引用仓库中不存在文件的 cursor movement 测试；未修改这些无关问题。
+
+## 人工验证范围
+
+当前环境未启动 Tauri/Vite 窗口进行真实 GUI 高频输出压测，因此仍建议在本地打开多个聊天会话，让一个会话持续输出并反复切换 Tab、分屏和 Workspan，确认 UI 响应、输出完整性及 TUI 颜色恢复。

--- a/docs/superpowers/plans/2026-08-06-terminal-tab-switch-output-freeze.md
+++ b/docs/superpowers/plans/2026-08-06-terminal-tab-switch-output-freeze.md
@@ -1,0 +1,270 @@
+# 多会话持续输出时切换 Tab 卡死实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 限制后台聊天会话的 xterm 输出批次，并跳过隐藏会话的 TUI 后处理，避免持续输出阻塞 Tab 切换，同时保持完整输出和 ACK 契约。
+
+**Architecture:** `useTerminalDisplay` 继续拥有每个会话的 PTY 输出队列，但 live frame 只按完整 frame 边界合并到固定字节预算；每批 write callback 完成后再调度下一批。`terminalTuiColorSync` 增加可见性判断，`XTermTerminal` 仅在可见状态触发颜色同步，切回可见时由现有 visibility effect 补做一次同步。
+
+**Tech Stack:** React hooks、TypeScript、`@xterm/xterm`、Node.js 内置测试运行器、TypeScript 编译器、Vite。
+
+## Global Constraints
+
+- 不修改 daemon、PTY 边界、ConPTY、ACK 时机、Replay/Reset 屏障或 xterm 版本。
+- live frame 只在完整 frame 边界合并；单个超预算 frame 独立处理，不在前端二次切割 ANSI/UTF-8。
+- ACK 只能来自 xterm `write` callback 之后的现有 `TerminalOutputDelivery.commit()` 路径。
+- 隐藏会话继续写入 xterm 并保留完整 buffer，只跳过 TUI 颜色/背景后处理。
+- 不新增依赖；所有用户可见 PR 文案使用中文。
+- 每个实现步骤遵循先写失败测试、确认失败、再写最小生产代码、确认通过。
+
+---
+
+### Task 1: 锁定有界 live 批处理回归
+
+**Files:**
+- Modify: `scripts/terminalReplay.test.mjs`，在现有 `FakeTerminal` 输出队列测试之后增加连续 live frame 场景。
+- Create: `scripts/terminalTuiColorSync.test.mjs`，测试隐藏状态不触发 TUI 扫描。
+
+**Interfaces:**
+- Consumes: 当前 `useTerminalDisplay().attachPtyOutput()`、`managerStub.emitOutput()`、`FakeTerminal.finishNextWrite()` 和 `createTerminalTuiColorSyncController()`。
+- Produces: 对批次上限、write callback 顺序、ACK 顺序和隐藏颜色同步的失败回归。
+
+- [ ] **Step 1: 增加连续 live frame 的失败测试**
+
+在 `scripts/terminalReplay.test.mjs` 使用两个 40 KiB 的 live frame；目标预算为 64 KiB，所以期望第一帧单独写入，第一帧 callback 和下一动画帧之后才写入第二帧：
+
+```js
+test("continuous live output yields between bounded xterm writes", async () => {
+  managerStub.resetManager();
+  const { display, terminal, events, detachViewport } = createDisplay();
+  const commits = [];
+  const output = display.attachPtyOutput();
+  await output.ready;
+  const firstText = "a".repeat(40 * 1024);
+  const secondText = "b".repeat(40 * 1024);
+
+  managerStub.emitOutput(delivery(frame(3, firstText, 120, 30), commits));
+  managerStub.emitOutput(delivery(frame(4, secondText, 120, 30), commits));
+  flushNextAnimationFrame();
+
+  assert.deepEqual(events, [`write:${firstText}`]);
+  terminal.finishNextWrite();
+  flushNextAnimationFrame();
+  assert.deepEqual(events, [`write:${firstText}`, `write:${secondText}`]);
+  terminal.finishNextWrite();
+  assert.deepEqual(commits, [
+    { sequence: 3, charCount: firstText.length },
+    { sequence: 4, charCount: secondText.length },
+  ]);
+  output.dispose();
+  detachViewport();
+});
+```
+
+- [ ] **Step 2: 增加隐藏 TUI 同步的失败测试**
+
+创建临时模块替换 `terminalTuiDisplay` 和 `TerminalCliContext`，让 `normalizeTerminalTuiComposerBackground()` 记录调用次数；先以 `isVisible: false` 直接调用 controller 的 `normalize()` 和调度回调，期望调用次数为 0，再切换为 `true`，期望调用次数为 1。测试只验证可见性策略，不依赖真实 DOM 或 xterm renderer：
+
+```js
+const options = { isVisible: false, isTransparent: false, isLightTheme: false,
+  terminalTextColor: undefined, tuiUserColor: undefined, tuiAssistantColor: undefined,
+  getContext: () => ({}) };
+const controller = createTerminalTuiColorSyncController(() => options);
+controller.normalize({});
+assert.equal(normalizeCalls, 0);
+options.isVisible = true;
+controller.normalize({});
+assert.equal(normalizeCalls, 1);
+```
+
+- [ ] **Step 3: 运行新增测试确认按预期失败**
+
+运行：
+
+```bash
+node --test scripts/terminalReplay.test.mjs scripts/terminalTuiColorSync.test.mjs
+```
+
+预期：有界 live write 测试失败并显示当前一次写入包含两个 40 KiB frame；隐藏 TUI 测试失败并显示当前 controller 仍执行扫描。基线已有的 Replay 测试保持通过。
+
+### Task 2: 实现有界 live 输出批处理
+
+**Files:**
+- Modify: `src/hooks/useTerminalDisplay.ts:24-47`，增加批次预算和 `PendingTerminalWrite.byteLength`。
+- Modify: `src/hooks/useTerminalDisplay.ts:252-340`，限制连续 live frame 合并范围。
+- Test: `scripts/terminalReplay.test.mjs`。
+
+**Interfaces:**
+- Consumes: `TerminalBinaryFrame.data.byteLength` 和现有 `TerminalOutputDelivery.commit()`。
+- Produces: `terminal.write()` 每次最多合并 `PTY_LIVE_WRITE_BATCH_BYTES` 的连续 live frame，并继续调用每个 frame 的 commit。
+
+- [ ] **Step 1: 增加原始字节长度和预算常量**
+
+在 `HIDDEN_WEBGL_DISPOSE_DELAY_MS` 旁增加：
+
+```ts
+const PTY_LIVE_WRITE_BATCH_BYTES = 64 * 1024;
+```
+
+在 `PendingTerminalWrite` 增加：
+
+```ts
+byteLength: number;
+```
+
+在 `queuePayload()` 推入队列时设置 `byteLength: payload.data.byteLength`。
+
+- [ ] **Step 2: 让 live flush 在 frame 边界达到预算即停止**
+
+保留 Replay/Reset 的单项屏障；将普通 live 分支改为按预算收集：
+
+```ts
+const first = ptyPendingChunksRef.current.shift();
+if (!first) return;
+const pending = [first];
+let pendingBytes = first.byteLength;
+if (!first.replay && !first.reset) {
+  while (ptyPendingChunksRef.current[0]) {
+    const next = ptyPendingChunksRef.current[0];
+    if (next.replay || next.reset) break;
+    if (pending.length > 0 && pendingBytes + next.byteLength > PTY_LIVE_WRITE_BATCH_BYTES) break;
+    pending.push(ptyPendingChunksRef.current.shift()!);
+    pendingBytes += next.byteLength;
+  }
+} else {
+  // 保持现有 Replay/Reset 尺寸屏障逻辑不变。
+}
+```
+
+一个超预算的首 frame 会独立处理；后续 frame 会留在队列中，由 write callback 后的下一动画帧继续处理。
+
+- [ ] **Step 3: 运行有界批处理测试确认通过**
+
+运行：
+
+```bash
+node --test scripts/terminalReplay.test.mjs
+```
+
+预期：连续 live output 测试和全部既有 Replay/Reset/resize 测试通过，两个 frame 的 commit 和 ACK 顺序仍为 3、4。
+
+- [ ] **Step 4: 提交独立的输出队列修复**
+
+```bash
+git add src/hooks/useTerminalDisplay.ts scripts/terminalReplay.test.mjs
+git commit -m "fix(terminal): bound live output batches"
+```
+
+### Task 3: 让隐藏会话跳过 TUI 后处理
+
+**Files:**
+- Modify: `src/lib/terminalTuiColorSync.ts:14-68`，在 controller options 中加入 `isVisible` 并在 normalize 入口拦截隐藏状态。
+- Modify: `src/components/XTermTerminal.tsx:667-676`，向 controller 提供当前可见性。
+- Modify: `src/components/XTermTerminal.tsx:758-761`、`869-870`、`1593-1599`，隐藏状态不调用 normalize/schedule；可见性 effect 保留一次完整同步。
+- Test: `scripts/terminalTuiColorSync.test.mjs`。
+
+**Interfaces:**
+- Consumes: `isVisibleRef.current`。
+- Produces: 隐藏终端的 controller normalize 直接返回；可见性恢复 effect 继续调用现有 normalize/schedule。
+
+- [ ] **Step 1: 增加 controller 的可见性输入和失败行为**
+
+把 `TerminalTuiColorSyncOptions` 增加：
+
+```ts
+isVisible: boolean;
+```
+
+并在 `normalize()` 读取 options 后立即加入：
+
+```ts
+if (!options.isVisible) return;
+```
+
+在 `XTermTerminal` 的 `getOptions` 返回值中加入 `isVisible: isVisibleRef.current`。
+
+- [ ] **Step 2: 收紧写入、主题和 render/scroll 触发点**
+
+调用点统一使用当前可见性：
+
+```ts
+displayAfterWriteRef.current = (terminal) => {
+  if (!isVisibleRef.current) return;
+  tuiColorSync.normalize(terminal);
+  tuiColorSync.schedule(terminal);
+};
+```
+
+主题 effect 和 `terminal.onRender`、`terminal.onScroll` 也只在 `isVisibleRef.current` 为真时触发同步；已有 `isVisible` effect 在切回可见时保留 `normalize()` 和 `schedule()`，作为唯一补偿入口。
+
+- [ ] **Step 3: 运行隐藏状态回归和已有终端测试**
+
+运行：
+
+```bash
+node --test scripts/terminalTuiColorSync.test.mjs scripts/terminalReplay.test.mjs scripts/terminalVisibility.test.mjs
+```
+
+预期：隐藏 controller 不调用 TUI 扫描，可见 controller 调用一次；所有终端 Replay、resize 和 visibility 测试通过。
+
+- [ ] **Step 4: 提交隐藏后处理修复**
+
+```bash
+git add src/lib/terminalTuiColorSync.ts src/components/XTermTerminal.tsx scripts/terminalTuiColorSync.test.mjs
+git commit -m "fix(terminal): skip hidden TUI post-processing"
+```
+
+### Task 4: 全量验证和交付
+
+**Files:**
+- Modify: `.trellis/tasks/08-06-fix-terminal-tab-switch-output-freeze/design.md` only if implementation evidence requires a factual correction。
+- Create: `.trellis/tasks/08-06-fix-terminal-tab-switch-output-freeze/pr-body.md`，记录中文 PR 描述。
+- Test: `scripts/terminalReplay.test.mjs`、`scripts/terminalTuiColorSync.test.mjs` 以及项目现有 Node 测试。
+
+**Interfaces:**
+- Consumes: Task 2 和 Task 3 的可验证行为。
+- Produces: 可审查的中文 PR 分支和验证记录。
+
+- [ ] **Step 1: 运行所有现有 Node 回归测试**
+
+运行：
+
+```powershell
+Get-ChildItem scripts -Filter '*.test.mjs' | ForEach-Object { node --test $_.FullName }
+```
+
+预期：所有测试进程退出码为 0；若发现与本次改动无关的基线失败，记录测试文件和原始错误，不修改无关代码。
+
+- [ ] **Step 2: 运行静态检查、构建和 diff 检查**
+
+运行：
+
+```bash
+npx tsc --noEmit
+npm run build
+git diff --check
+git status --short
+```
+
+预期：TypeScript 无错误，Vite 构建退出码为 0，diff 无空白错误，工作区只包含设计/计划、三个实现文件和两个测试文件（以及交付阶段新增的中文 PR body）。
+
+- [ ] **Step 3: 执行人工场景验证**
+
+在本地 Vite/Tauri 窗口中打开至少三个聊天会话，让一个会话持续产生 Claude/Codex 高频输出，在输出过程中反复切换 Tab、分屏和 Workspan；确认 UI 可响应、切回后输出完整且 TUI 颜色正常。再验证普通 shell、Replay 和断线重连场景。
+
+- [ ] **Step 4: 运行变更影响检查并请求代码审查**
+
+GitNexus 当前不可用，因此用 `rg`、`git diff --stat` 和人工调用链检查确认触点只在终端显示层；审查重点是 frame 边界、ACK 顺序、隐藏可见切换和重挂载行为。代码审查通过后再继续推送。
+
+- [ ] **Step 5: 合并提交并创建中文 PR**
+
+```bash
+git push -u origin codex/fix-terminal-tab-switch-output-freeze
+gh pr create --repo dark-hxx/CLI-Manager \
+  --base master \
+  --head nova-bryan:codex/fix-terminal-tab-switch-output-freeze \
+  --title "修复：多会话持续输出时切换 Tab 卡死" \
+  --body-file .trellis/tasks/08-06-fix-terminal-tab-switch-output-freeze/pr-body.md
+```
+
+PR body 必须使用中文，包含问题现象、根因、两项修复、ACK/Replay 保持不变、自动化测试、构建结果和人工验证范围。

--- a/scripts/terminalReplay.test.mjs
+++ b/scripts/terminalReplay.test.mjs
@@ -551,7 +551,11 @@ test("continuous live output yields between bounded xterm writes", async () => {
   flushNextAnimationFrame();
 
   assert.deepEqual(events, [`write:${firstText}`]);
+  assert.deepEqual(commits, []);
   terminal.finishNextWrite();
+  assert.deepEqual(commits, [
+    { sequence: 3, charCount: firstText.length },
+  ]);
   flushNextAnimationFrame();
   assert.deepEqual(events, [`write:${firstText}`, `write:${secondText}`]);
   terminal.finishNextWrite();

--- a/scripts/terminalReplay.test.mjs
+++ b/scripts/terminalReplay.test.mjs
@@ -536,3 +536,29 @@ test("resize-only reconnect replay is applied locally before current-size fit", 
   output.dispose();
   detachViewport();
 });
+
+test("continuous live output yields between bounded xterm writes", async () => {
+  managerStub.resetManager();
+  const { display, terminal, events, detachViewport } = createDisplay();
+  const commits = [];
+  const output = display.attachPtyOutput();
+  await output.ready;
+  const firstText = "a".repeat(40 * 1024);
+  const secondText = "b".repeat(40 * 1024);
+
+  managerStub.emitOutput(delivery(frame(3, firstText, 120, 30), commits));
+  managerStub.emitOutput(delivery(frame(4, secondText, 120, 30), commits));
+  flushNextAnimationFrame();
+
+  assert.deepEqual(events, [`write:${firstText}`]);
+  terminal.finishNextWrite();
+  flushNextAnimationFrame();
+  assert.deepEqual(events, [`write:${firstText}`, `write:${secondText}`]);
+  terminal.finishNextWrite();
+  assert.deepEqual(commits, [
+    { sequence: 3, charCount: firstText.length },
+    { sequence: 4, charCount: secondText.length },
+  ]);
+  output.dispose();
+  detachViewport();
+});

--- a/scripts/terminalTuiColorSync.test.mjs
+++ b/scripts/terminalTuiColorSync.test.mjs
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+
+const tempDir = mkdtempSync(join(tmpdir(), "cli-manager-terminal-tui-color-sync-"));
+process.on("exit", () => rmSync(tempDir, { recursive: true, force: true }));
+
+globalThis.window = globalThis;
+globalThis.requestAnimationFrame = (callback) => {
+  callback(performance.now());
+  return 1;
+};
+globalThis.cancelAnimationFrame = () => {};
+
+writeFileSync(join(tempDir, "terminalTuiDisplay.mjs"), `
+export let normalizeCalls = 0;
+export function hasCodexTuiViewport() { return false; }
+export function hasKnownAiTuiViewport() { return false; }
+export function hasTuiComposerPromptViewport() { return false; }
+export function normalizeTerminalTuiComposerBackground() { normalizeCalls += 1; }
+`);
+writeFileSync(join(tempDir, "TerminalCliContext.mjs"), `
+export function isClaudeTerminalContext() { return false; }
+export function isCodexTerminalContext() { return false; }
+`);
+
+const source = readFileSync(new URL("../src/lib/terminalTuiColorSync.ts", import.meta.url), "utf8");
+const transpiled = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.ES2022,
+    target: ts.ScriptTarget.ES2022,
+  },
+  fileName: "terminalTuiColorSync.ts",
+}).outputText
+  .replace('from "./terminalTuiDisplay"', 'from "./terminalTuiDisplay.mjs"')
+  .replace('from "../terminal/browser/TerminalCliContext"', 'from "./TerminalCliContext.mjs"');
+const modulePath = join(tempDir, "terminalTuiColorSync.mjs");
+writeFileSync(modulePath, transpiled, "utf8");
+
+const { createTerminalTuiColorSyncController } = await import(pathToFileURL(modulePath).href);
+const tuiDisplayStub = await import(pathToFileURL(join(tempDir, "terminalTuiDisplay.mjs")).href);
+
+test("hidden terminal skips TUI color scanning until it becomes visible", () => {
+  const options = {
+    isVisible: false,
+    isTransparent: false,
+    isLightTheme: false,
+    terminalTextColor: undefined,
+    tuiUserColor: undefined,
+    tuiAssistantColor: undefined,
+    getContext: () => ({}),
+  };
+  const controller = createTerminalTuiColorSyncController(() => options);
+  controller.normalize({});
+  assert.equal(tuiDisplayStub.normalizeCalls, 0);
+
+  options.isVisible = true;
+  controller.normalize({});
+  assert.equal(tuiDisplayStub.normalizeCalls, 1);
+  controller.dispose();
+});

--- a/scripts/terminalTuiColorSync.test.mjs
+++ b/scripts/terminalTuiColorSync.test.mjs
@@ -9,15 +9,43 @@ import ts from "typescript";
 const tempDir = mkdtempSync(join(tmpdir(), "cli-manager-terminal-tui-color-sync-"));
 process.on("exit", () => rmSync(tempDir, { recursive: true, force: true }));
 
+const originalWindow = globalThis.window;
+const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+let nextAnimationFrameId = 1;
+const animationFrames = new Map();
+
 globalThis.window = globalThis;
 globalThis.requestAnimationFrame = (callback) => {
-  callback(performance.now());
-  return 1;
+  const frameId = nextAnimationFrameId++;
+  animationFrames.set(frameId, callback);
+  return frameId;
 };
-globalThis.cancelAnimationFrame = () => {};
+globalThis.cancelAnimationFrame = (frameId) => {
+  animationFrames.delete(frameId);
+};
+
+function flushNextAnimationFrame() {
+  const nextFrame = animationFrames.entries().next();
+  assert.equal(nextFrame.done, false, "expected a scheduled animation frame");
+  const [frameId, callback] = nextFrame.value;
+  animationFrames.delete(frameId);
+  callback(performance.now());
+}
+
+test.after(() => {
+  animationFrames.clear();
+  if (originalWindow === undefined) delete globalThis.window;
+  else globalThis.window = originalWindow;
+  if (originalRequestAnimationFrame === undefined) delete globalThis.requestAnimationFrame;
+  else globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+  if (originalCancelAnimationFrame === undefined) delete globalThis.cancelAnimationFrame;
+  else globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+});
 
 writeFileSync(join(tempDir, "terminalTuiDisplay.mjs"), `
 export let normalizeCalls = 0;
+export function resetNormalizeCalls() { normalizeCalls = 0; }
 export function hasCodexTuiViewport() { return false; }
 export function hasKnownAiTuiViewport() { return false; }
 export function hasTuiComposerPromptViewport() { return false; }
@@ -44,8 +72,8 @@ writeFileSync(modulePath, transpiled, "utf8");
 const { createTerminalTuiColorSyncController } = await import(pathToFileURL(modulePath).href);
 const tuiDisplayStub = await import(pathToFileURL(join(tempDir, "terminalTuiDisplay.mjs")).href);
 
-test("hidden terminal skips TUI color scanning until it becomes visible", () => {
-  const options = {
+function createOptions() {
+  return {
     isVisible: false,
     isTransparent: false,
     isLightTheme: false,
@@ -54,12 +82,36 @@ test("hidden terminal skips TUI color scanning until it becomes visible", () => 
     tuiAssistantColor: undefined,
     getContext: () => ({}),
   };
+}
+
+test("hidden terminal skips direct TUI color scanning until it becomes visible", (t) => {
+  tuiDisplayStub.resetNormalizeCalls();
+  const options = createOptions();
   const controller = createTerminalTuiColorSyncController(() => options);
+  t.after(() => controller.dispose());
+
   controller.normalize({});
   assert.equal(tuiDisplayStub.normalizeCalls, 0);
 
   options.isVisible = true;
   controller.normalize({});
   assert.equal(tuiDisplayStub.normalizeCalls, 1);
-  controller.dispose();
+});
+
+test("hidden terminal skips scheduled TUI color scanning until it becomes visible", (t) => {
+  tuiDisplayStub.resetNormalizeCalls();
+  const options = {
+    ...createOptions(),
+  };
+  const controller = createTerminalTuiColorSyncController(() => options);
+  t.after(() => controller.dispose());
+
+  controller.schedule({});
+  flushNextAnimationFrame();
+  assert.equal(tuiDisplayStub.normalizeCalls, 0);
+
+  options.isVisible = true;
+  controller.schedule({});
+  flushNextAnimationFrame();
+  assert.equal(tuiDisplayStub.normalizeCalls, 1);
 });

--- a/src/components/XTermTerminal.tsx
+++ b/src/components/XTermTerminal.tsx
@@ -667,6 +667,7 @@ export function XTermTerminal({ sessionId, isActive = true, isVisible = true, fo
   const tuiColorSync = useMemo(
     () => createTerminalTuiColorSyncController(() => ({
       getContext: getSessionToolContext,
+      isVisible: isVisibleRef.current,
       isTransparent: isTransparentRef.current,
       isLightTheme: isLightTerminalRef.current,
       terminalTextColor: terminalTextColorRef.current,
@@ -756,6 +757,7 @@ export function XTermTerminal({ sessionId, isActive = true, isVisible = true, fo
     || (runtimeTerminal !== undefined && hasCodexTuiViewport(runtimeTerminal))
   );
   displayAfterWriteRef.current = (terminal) => {
+    if (!isVisibleRef.current) return;
     tuiColorSync.normalize(terminal);
     tuiColorSync.schedule(terminal);
   };
@@ -866,8 +868,10 @@ export function XTermTerminal({ sessionId, isActive = true, isVisible = true, fo
     if (terminal.options.scrollback !== effectiveTerminalScrollbackRows) {
       terminal.options.scrollback = effectiveTerminalScrollbackRows;
     }
-    tuiColorSync.normalize(terminal);
-    tuiColorSync.schedule(terminal);
+    if (isVisibleRef.current) {
+      tuiColorSync.normalize(terminal);
+      tuiColorSync.schedule(terminal);
+    }
   }, [fontSize, effectiveFontFamily, effectiveTerminalScrollbackRows, resolvedTheme, terminalThemeName, terminalTextColor, terminalTuiUserColor, terminalTuiAssistantColor, lightThemePalette, darkThemePalette, isTransparent, background.overlayDarken, lowMemoryMode, disableHardwareAcceleration, linuxGraphicsDisableWebgl, searchOpen, tuiColorSync]);
 
   // Hidden terminals stay attached and continue parsing output. Visibility only
@@ -1592,10 +1596,10 @@ export function XTermTerminal({ sessionId, isActive = true, isVisible = true, fo
     displayDisposables.push({ dispose: detachViewport });
     displayDisposables.push(terminal.onRender((range) => {
       handleVisibilityRestoreRender(terminal, range);
-      tuiColorSync.schedule(terminal);
+      if (isVisibleRef.current) tuiColorSync.schedule(terminal);
     }));
     displayDisposables.push(terminal.onScroll(() => {
-      tuiColorSync.schedule(terminal);
+      if (isVisibleRef.current) tuiColorSync.schedule(terminal);
     }));
     const detachIme = attachIme(terminal, {
       forwarding: inputForwarding,

--- a/src/hooks/useTerminalDisplay.ts
+++ b/src/hooks/useTerminalDisplay.ts
@@ -24,6 +24,7 @@ import { useTerminalStore } from "../stores/terminalStore";
 const MIN_TERMINAL_COLS = 40;
 const MIN_TERMINAL_ROWS = 8;
 const HIDDEN_WEBGL_DISPOSE_DELAY_MS = 10_000;
+const PTY_LIVE_WRITE_BATCH_BYTES = 64 * 1024;
 
 type NormalizeTerminalOutput = (text: string) => string;
 type TransformTerminalOutput = (text: string) => string;
@@ -38,6 +39,7 @@ export interface TerminalOutputDiagnostics {
 interface PendingTerminalWrite {
   text: string;
   charCount: number;
+  byteLength: number;
   commit: ((charCount: number) => void) | null;
   replay: boolean;
   replayBatchEnd: boolean;
@@ -277,12 +279,23 @@ export function useTerminalDisplay({
       if (!first) return;
       const pending = [first];
       if (!first.replay && !first.reset) {
+        let pendingBytes = first.byteLength;
+        // Keep each live write bounded at complete PTY frame boundaries so a
+        // continuous producer cannot monopolize the WebView main thread.
         while (
           ptyPendingChunksRef.current[0]
           && !ptyPendingChunksRef.current[0].replay
           && !ptyPendingChunksRef.current[0].reset
         ) {
+          const next = ptyPendingChunksRef.current[0];
+          if (
+            pending.length > 0
+            && pendingBytes + next.byteLength > PTY_LIVE_WRITE_BATCH_BYTES
+          ) {
+            break;
+          }
           pending.push(ptyPendingChunksRef.current.shift()!);
+          pendingBytes += next.byteLength;
         }
       } else {
         forwardPtyResizeRef.current = false;
@@ -338,6 +351,7 @@ export function useTerminalDisplay({
       ptyPendingChunksRef.current.push({
         text,
         charCount: rawText.length,
+        byteLength: payload.data.byteLength,
         commit: delivery.commit,
         replay: payload.kind === "replay",
         replayBatchEnd: payload.replayBatchEnd === true,

--- a/src/lib/terminalTuiColorSync.ts
+++ b/src/lib/terminalTuiColorSync.ts
@@ -12,6 +12,7 @@ import {
 } from "../terminal/browser/TerminalCliContext";
 
 export interface TerminalTuiColorSyncOptions {
+  isVisible: boolean;
   isTransparent: boolean;
   isLightTheme: boolean;
   terminalTextColor?: string;
@@ -35,6 +36,9 @@ export function createTerminalTuiColorSyncController(
 
   const normalize = (terminal: Terminal) => {
     const options = getOptions();
+    // Hidden terminals still parse every PTY frame, but their TUI color scan only
+    // affects rendered cells. Defer that expensive work until the tab is visible.
+    if (!options.isVisible) return;
     const context = options.getContext();
     const hasContextualTuiPrompt = (
       (isCodexTerminalContext(context) || isClaudeTerminalContext(context))


### PR DESCRIPTION
## 问题现象

当多个聊天会话同时打开，其中一个会话持续输出时切换 Tab，WebView 主线程可能被长时间占用，表现为整个 App 卡死。隐藏会话仍保持挂载，持续输出期间还会触发终端 TUI 颜色/背景扫描，进一步放大阻塞。

## 根因

前端输出队列会在一次动画帧中无界合并连续 live PTY frame，最终调用一次超大的 `terminal.write()`。xterm 在写入过程中执行解析和渲染，隐藏会话的 TUI 颜色/背景扫描也同步运行，导致 Tab 切换、React 渲染和输入事件无法及时得到主线程调度。

## 修改内容

1. 为连续 live 输出增加 64 KiB 原始 frame 字节预算，只在完整 PTY frame 边界合并；超预算 frame 独立写入，后续批次等待当前 xterm `write` callback 和下一动画帧。
2. 隐藏会话继续写入 xterm 并保留完整 buffer，但跳过 TUI 颜色/背景扫描；切回可见时由现有可见性 effect 补做一次同步。

Replay/Reset 屏障、PTY frame 边界、xterm `write` callback 后的 `TerminalOutputDelivery.commit()`/ACK 时序均保持不变；未修改 daemon、ConPTY、xterm 版本或依赖。

## 验证

- `terminalReplay.test.mjs`：13/13 通过。
- `terminalTuiColorSync.test.mjs`、`terminalVisibility.test.mjs` 及相关终端测试：19/19 通过。
- `npx tsc --noEmit`：通过。
- `npm run build`：通过。
- `git diff --check`：通过。

全量 `scripts/*.test.mjs` 还存在 3 项与本次改动无关的基线/环境失败：缺少 `cargo` 的 Codex proxy E2E、旧版 SSH agent 版本断言，以及引用仓库中不存在文件的 cursor movement 测试；未修改这些无关问题。

## 人工验证范围

当前环境未启动 Tauri/Vite 窗口进行真实 GUI 高频输出压测，因此仍建议在本地打开多个聊天会话，让一个会话持续输出并反复切换 Tab、分屏和 Workspan，确认 UI 响应、输出完整性及 TUI 颜色恢复。
