### PR TITLE
fix(desktop-pet): prevent status bubble clipping

### DIFF
--- a/src-tauri/src/commands/desktop_pet.rs
+++ b/src-tauri/src/commands/desktop_pet.rs
@@ -8,9 +8,7 @@ use std::fs;
 use std::io::Cursor;
 use std::path::{Component, Path, PathBuf};
 use std::time::{Duration, SystemTime};
-#[cfg(not(target_os = "windows"))]
-use tauri::PhysicalSize;
-use tauri::{AppHandle, LogicalSize, Manager, PhysicalPosition, Runtime};
+use tauri::{AppHandle, Manager, PhysicalPosition, PhysicalSize, Runtime};
 use uuid::Uuid;
 use zip::ZipArchive;
 
@@ -1148,6 +1146,102 @@ fn window_size(scale: f64) -> (f64, f64) {
     )
 }
 
+fn physical_window_size(scale: f64, scale_factor: f64) -> (u32, u32) {
+    let scale_factor = if scale_factor.is_finite() && scale_factor > 0.0 {
+        scale_factor
+    } else {
+        1.0
+    };
+    let (width, height) = window_size(scale);
+    (
+        (width * scale_factor).round().max(1.0) as u32,
+        (height * scale_factor).round().max(1.0) as u32,
+    )
+}
+
+fn desired_window_geometry<R: Runtime>(
+    window: &tauri::WebviewWindow<R>,
+    config: &DesktopPetWindowConfig,
+) -> ((u32, u32), Option<(i32, i32)>) {
+    // A hidden window can still report its previous monitor, so resolve DPI from the saved target.
+    let monitor = if let Some(position) = config.position.as_ref() {
+        window
+            .monitor_from_point(position.x as f64 + 1.0, position.y as f64 + 1.0)
+            .ok()
+            .flatten()
+            .or_else(|| window.current_monitor().ok().flatten())
+            .or_else(|| window.primary_monitor().ok().flatten())
+    } else {
+        window
+            .primary_monitor()
+            .ok()
+            .flatten()
+            .or_else(|| window.current_monitor().ok().flatten())
+    };
+    let scale_factor = monitor
+        .as_ref()
+        .map(|monitor| monitor.scale_factor())
+        .or_else(|| window.scale_factor().ok())
+        .unwrap_or(1.0);
+    let size = physical_window_size(config.scale, scale_factor);
+    let position = config
+        .position
+        .as_ref()
+        .map(|position| (position.x, position.y))
+        .or_else(|| {
+            monitor.map(|monitor| {
+                let monitor_position = monitor.position();
+                let monitor_size = monitor.size();
+                (
+                    monitor_position.x + monitor_size.width as i32
+                        - size.0 as i32
+                        - PET_WINDOW_MARGIN,
+                    monitor_position.y + monitor_size.height as i32
+                        - size.1 as i32
+                        - PET_WINDOW_MARGIN
+                        - 40,
+                )
+            })
+        });
+    (size, position)
+}
+
+fn apply_window_geometry<R: Runtime>(
+    window: &tauri::WebviewWindow<R>,
+    size: (u32, u32),
+    position: Option<(i32, i32)>,
+) -> Result<(), String> {
+    if let Some((x, y)) = position {
+        window
+            .set_position(PhysicalPosition::new(x, y))
+            .map_err(|err| format!("pet_window_position_failed: {err}"))?;
+    }
+    window
+        .set_size(PhysicalSize::new(size.0, size.1))
+        .map_err(|err| format!("pet_window_resize_failed: {err}"))
+}
+
+fn ensure_window_geometry<R: Runtime>(
+    window: &tauri::WebviewWindow<R>,
+    size: (u32, u32),
+    position: Option<(i32, i32)>,
+) -> Result<(), String> {
+    let size_mismatch = window
+        .inner_size()
+        .map(|actual| actual.width.abs_diff(size.0) > 1 || actual.height.abs_diff(size.1) > 1)
+        .unwrap_or(true);
+    let position_mismatch = position.is_some_and(|(x, y)| {
+        window
+            .outer_position()
+            .map(|actual| actual.x.abs_diff(x) > 1 || actual.y.abs_diff(y) > 1)
+            .unwrap_or(true)
+    });
+    if size_mismatch || position_mismatch {
+        apply_window_geometry(window, size, position)?;
+    }
+    Ok(())
+}
+
 fn place_default<R: Runtime>(window: &tauri::WebviewWindow<R>) {
     let Ok(Some(monitor)) = window.primary_monitor() else {
         return;
@@ -1186,23 +1280,24 @@ pub fn desktop_pet_window_sync(
         return Ok(());
     }
 
-    let (width, height) = window_size(config.scale);
-    window
-        .set_size(LogicalSize::new(width, height))
-        .map_err(|err| format!("pet_window_resize_failed: {err}"))?;
+    // Pet scaling is application-controlled; persisted WebView2 zoom must not shrink its viewport.
+    #[cfg(target_os = "windows")]
+    let _ = window.set_zoom(1.0);
+
+    let (size, position) = desired_window_geometry(&window, &config);
+    apply_window_geometry(&window, size, position)?;
     window
         .set_always_on_top(config.always_on_top)
         .map_err(|err| format!("pet_window_topmost_failed: {err}"))?;
-    if let Some(position) = config.position {
-        window
-            .set_position(PhysicalPosition::new(position.x, position.y))
-            .map_err(|err| format!("pet_window_position_failed: {err}"))?;
-    } else {
-        place_default(&window);
-    }
     window
         .show()
         .map_err(|err| format!("pet_window_show_failed: {err}"))?;
+
+    #[cfg(target_os = "windows")]
+    window
+        .set_zoom(1.0)
+        .map_err(|err| format!("pet_window_zoom_reset_failed: {err}"))?;
+    ensure_window_geometry(&window, size, position)?;
 
     #[cfg(target_os = "windows")]
     window
@@ -1352,6 +1447,21 @@ mod tests {
         assert_eq!(window_size(1.0), (190.0, 210.0));
         assert_eq!(window_size(1.5), (285.0, 315.0));
         assert_eq!(window_size(2.0), (285.0, 315.0));
+    }
+
+    #[test]
+    fn desktop_pet_physical_window_size_tracks_monitor_dpi() {
+        assert_eq!(physical_window_size(1.0, 1.0), (190, 210));
+        assert_eq!(physical_window_size(1.25, 1.0), (238, 263));
+        assert_eq!(physical_window_size(1.0, 1.25), (238, 263));
+        assert_eq!(physical_window_size(1.25, 1.25), (297, 328));
+        assert_eq!(physical_window_size(1.5, 1.5), (428, 473));
+    }
+
+    #[test]
+    fn desktop_pet_physical_window_size_rejects_invalid_dpi() {
+        assert_eq!(physical_window_size(1.0, 0.0), (190, 210));
+        assert_eq!(physical_window_size(1.0, f64::NAN), (190, 210));
     }
 
     fn fake_png(width: u32, height: u32) -> Vec<u8> {

--- a/src/hooks/useDesktopPetCoordinator.ts
+++ b/src/hooks/useDesktopPetCoordinator.ts
@@ -224,6 +224,21 @@ export function useDesktopPetCoordinator({
   updateSettingRef.current = updateSetting;
   petWindowVisibleRef.current = petWindowVisible;
 
+  const synchronizeDesktopPetWindow = useCallback(async () => {
+    const settingsState = useSettingsStore.getState();
+    if (!settingsState.loaded) return;
+    const current = settingsState.desktopPet;
+    await emitTo(DESKTOP_PET_WINDOW_LABEL, DESKTOP_PET_CLOSE_MENU_EVENT).catch(() => {});
+    await invoke("desktop_pet_window_sync", {
+      config: {
+        enabled: petWindowVisibleRef.current,
+        alwaysOnTop: current.alwaysOnTop,
+        scale: desktopPetScale(current.size),
+        position: current.position,
+      },
+    });
+  }, []);
+
   const sendState = useCallback(async (force = false) => {
     const stats = deliveryStatsRef.current;
     stats.requests += 1;
@@ -325,17 +340,9 @@ export function useDesktopPetCoordinator({
       petAppliedWindowConfigKeyRef.current = null;
       return;
     }
-    void (async () => {
-      await emitTo(DESKTOP_PET_WINDOW_LABEL, DESKTOP_PET_CLOSE_MENU_EVENT).catch(() => {});
-      await invoke("desktop_pet_window_sync", {
-        config: {
-          enabled: petWindowVisible,
-          alwaysOnTop: desktopPet.alwaysOnTop,
-          scale: desktopPetScale(desktopPet.size),
-          position: desktopPet.position,
-        },
-      });
-    })().catch((err) => logWarn("Failed to synchronize desktop pet window", err));
+    void synchronizeDesktopPetWindow().catch((err) => {
+      logWarn("Failed to synchronize desktop pet window", err);
+    });
   }, [
     appReady,
     desktopPet.alwaysOnTop,
@@ -343,6 +350,7 @@ export function useDesktopPetCoordinator({
     desktopPet.size,
     petWindowVisible,
     settingsLoaded,
+    synchronizeDesktopPetWindow,
   ]);
 
   useEffect(() => {
@@ -352,7 +360,14 @@ export function useDesktopPetCoordinator({
 
   useEffect(() => {
     const unlistenReady = listen(DESKTOP_PET_READY_EVENT, () => {
-      void sendState(true);
+      void (async () => {
+        try {
+          await synchronizeDesktopPetWindow();
+        } catch (err) {
+          logWarn("Failed to resynchronize ready desktop pet window", err);
+        }
+        await sendState(true);
+      })();
     });
     const unlistenOpenTarget = listen<DesktopPetOpenTargetPayload>(DESKTOP_PET_OPEN_TARGET_EVENT, (event) => {
       void (async () => {
@@ -435,7 +450,7 @@ export function useDesktopPetCoordinator({
       void unlistenPosition.then((unlisten) => unlisten());
       void unlistenSizeChange.then((unlisten) => unlisten());
     };
-  }, [sendState]);
+  }, [sendState, synchronizeDesktopPetWindow]);
 }
 
 function desktopPetWindowConfigKey(

--- a/verification.md
+++ b/verification.md
@@ -886,3 +886,21 @@
 - `node scripts/remoteHandoff.test.mjs`：5 项通过。
 - `cargo fmt --all -- --check`、`cargo check`、`npx tsc --noEmit`、`npm run build`、`git diff --check`：通过。
 - 尚未执行真实 Telegram、微信、飞书、企业微信授权及安装包冒烟；该项留给后续打包测试阶段。
+
+## 桌宠状态气泡顶部裁切修复（2026-08-06）
+
+### 根因与发现清单
+
+- 根因位于桌宠 CSS 缩放与 Tauri 原生窗口尺寸的同步边界：宠物画面和状态气泡已按用户尺寸渲染时，隐藏窗口首次显示、WebView2 残留缩放或跨 DPI 显示器恢复可能仍保留基础 `190 x 210` 窗口，超出透明 WebView 顶边的气泡会被根节点裁切。
+- `desktop_pet_window_sync` 现在按目标显示器 DPI 直接计算物理窗口尺寸，先应用目标位置和尺寸，显示后校验并在窗口管理器改写几何信息时重新应用；Windows 桌宠 WebView 同时恢复为 100% 页面缩放。
+- 桌宠窗口发出 ready 事件后会强制重跑一次原生窗口同步，再发送配置与状态，覆盖首次显示时窗口尚未稳定的时序。
+- 已修改 `src-tauri/src/commands/desktop_pet.rs` 与 `src/hooks/useDesktopPetCoordinator.ts`；已复核但未修改状态气泡 CSS、宠物资源解析、目录扫描、菜单展开几何、任务状态和远程托管逻辑。
+- GitNexus MCP 当前未暴露；已降级使用 codebase-memory moderate 索引、调用路径、`rg`、源码和 Git diff。工作区检测仅包含上述两处实现及本验证记录。
+
+### 场景与验证
+
+- 覆盖宠物尺寸 40%～150%、显示器 DPI 100%/125%/150%、保存位置与默认位置、隐藏窗口首次显示、桌宠 ready 后恢复，以及 Windows WebView2 非 100% 残留缩放。
+- `cargo test desktop_pet --lib`：15 项通过，包含新增的尺寸与 DPI 组合测试。
+- `node --test scripts/desktopPetSize.test.mjs scripts/desktopPetMenuGeometry.test.mjs scripts/desktopPetTransport.test.mjs scripts/desktopPetStatus.test.mjs`：25 项通过。
+- `npx tsc --noEmit`、`npm run build`、`cargo check`、`cargo fmt -- --check`、`git diff --check`：通过。
+- 当前机器未复现 Issue #196 用户的 WebView2/显示器状态；最终仍需由受影响 Windows 11 机器验证内置小猫和 Codex Pets 在原尺寸设置下的气泡完整性。


### PR DESCRIPTION
  ## 问题背景                                                                                                          
                                                                                                                       
  修复 #196 中桌宠状态气泡顶部显示不完整的问题。                                                                       
                                                                                                                       
 问题原因是桌宠 CSS 缩放尺寸与 Tauri 原生窗口尺寸、显示器 DPI 和 WebView2 缩放状态不同步，导致超出透明窗口边界的气泡内
  容被裁切。                                                                                                           
                                                                                                                       
  ## 修改内容                                                                                                          
                                                                                                                       
  - 根据宠物显示尺寸和目标显示器 DPI 计算原生窗口物理尺寸                                                              
  - 桌宠窗口显示后重新校验并同步窗口位置和尺寸                                                                         
  - Windows 平台恢复 WebView2 为 100% 缩放，避免重复缩放                                                               
  - 桌宠页面 ready 后主动触发一次窗口几何同步                                                                          
  - 保持现有 `.codex-pet` 扫描和宠物加载逻辑不变                                                                       
                                                                                                                       
  ## 验证结果                                                                                                          
                                                                                                                       
  - `cargo test desktop_pet --lib`：15 项通过                                                                          
  - 桌宠相关 Node 测试：25 项通过                                                                                      
  - `npx tsc --noEmit`：通过                                                                                           
  - 前端生产构建和 Rust `cargo check`：通过                                                                            
                                                                                                                       
  ## 验证说明                                                                                                          
                                                                                                                       
  该修复覆盖不同宠物尺寸、显示器 DPI 和 WebView2 缩放不一致导致的窗口裁切场景，仍建议由 #196 反馈用户在原设备上进行实机
  复测。                                                                                                               
