### PR TITLE
fix(remote-handoff): 修复 Codex Provider 注入与子进程密钥转发

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [TEMP] - 2026-08-11
 
+### 远程托管
+
+- 修复项目 Provider 锁定逻辑把运行时专用的 `--profile` 传给 Codex app-server、导致 cc-connect 启动探针立即失败的问题；app-server 继续使用完整 `-c` 覆盖锁定登记 Provider，普通 Codex 运行命令仍保留生成的 Provider profile。
+- 修复 Provider 密钥只注入 cc-connect 父进程、未传入 Codex Agent 子进程的问题；受管配置仅保存环境变量占位符，不落盘密钥明文。
+
 ### 文件面板路径复制与跨项目拖拽
 
 - 处理文件面板路径复制与跨项目终端拖拽需求：支持复制文件/目录的相对路径和绝对路径；从一个项目的文件面板拖拽到另一个项目的终端时使用绝对路径。（Refs #202）

--- a/scripts/codexAppServerProxy.e2e.test.mjs
+++ b/scripts/codexAppServerProxy.e2e.test.mjs
@@ -20,6 +20,9 @@ const proxyEnvironmentKeys = [
   "CLI_MANAGER_CODEX_ENV_KEY_OVERRIDE",
   "CLI_MANAGER_CODEX_MODEL_CATALOG_OVERRIDE",
   "CLI_MANAGER_CODEX_MODEL_OVERRIDE",
+  "CLI_MANAGER_CODEX_MODEL_PROVIDER",
+  "CLI_MANAGER_CODEX_PROFILE_NAME",
+  "CLI_MANAGER_CODEX_PROVIDER_NAME_OVERRIDE",
   "CLI_MANAGER_CODEX_WIRE_API_OVERRIDE",
   "CLI_MANAGER_CODEX_SSH_LAUNCH",
   "CLI_MANAGER_TEST_API_KEY",
@@ -107,15 +110,19 @@ function runProxy({
   });
   if (provider) {
     Object.assign(environment, {
+      CLI_MANAGER_CODEX_PROFILE_NAME: "cli-manager-project-provider-123",
+      CLI_MANAGER_CODEX_MODEL_PROVIDER: "custom",
+      CLI_MANAGER_CODEX_PROVIDER_NAME_OVERRIDE:
+        "model_providers.custom.name=CLI-Manager remote",
       CLI_MANAGER_CODEX_BASE_URL_OVERRIDE:
-        "model_providers.cli_manager_remote.base_url=https://provider.example.com/v1",
+        "model_providers.custom.base_url=https://provider.example.com/v1",
       CLI_MANAGER_CODEX_ENV_KEY_OVERRIDE:
-        "model_providers.cli_manager_remote.env_key=CLI_MANAGER_TEST_API_KEY",
+        "model_providers.custom.env_key=CLI_MANAGER_TEST_API_KEY",
       CLI_MANAGER_CODEX_MODEL_CATALOG_OVERRIDE:
         'model_catalog_json="C:/Users/test/CLI Manager/cli-manager-model-catalog.json"',
       CLI_MANAGER_CODEX_MODEL_OVERRIDE: "model=gpt-5.4",
       CLI_MANAGER_CODEX_WIRE_API_OVERRIDE:
-        "model_providers.cli_manager_remote.wire_api=responses",
+        "model_providers.custom.wire_api=responses",
       CLI_MANAGER_TEST_API_KEY: providerSecret,
     });
   }
@@ -227,15 +234,15 @@ process.exitCode = Number(process.env.FAKE_CODEX_EXIT_CODE || "0");
   assert.equal(withProvider.result.status, 0, "proxy must complete through a CMD launcher");
   assert.deepEqual(withProvider.capture.args, [
     "-c",
-    "model_provider=cli_manager_remote",
+    'model_provider="custom"',
     "-c",
-    "model_providers.cli_manager_remote.name=CLI-Manager remote",
+    "model_providers.custom.name=CLI-Manager remote",
     "-c",
-    "model_providers.cli_manager_remote.base_url=https://provider.example.com/v1",
+    "model_providers.custom.base_url=https://provider.example.com/v1",
     "-c",
-    "model_providers.cli_manager_remote.env_key=CLI_MANAGER_TEST_API_KEY",
+    "model_providers.custom.env_key=CLI_MANAGER_TEST_API_KEY",
     "-c",
-    "model_providers.cli_manager_remote.wire_api=responses",
+    "model_providers.custom.wire_api=responses",
     "-c",
     'model_catalog_json="C:/Users/test/CLI Manager/cli-manager-model-catalog.json"',
     "-c",
@@ -262,16 +269,18 @@ process.exitCode = Number(process.env.FAKE_CODEX_EXIT_CODE || "0");
   });
   assert.equal(passthrough.result.status, 17, "shim must forward ordinary Codex exit codes");
   assert.deepEqual(passthrough.capture.args, [
+    "--profile",
+    "cli-manager-project-provider-123",
     "-c",
-    "model_provider=cli_manager_remote",
+    'model_provider="custom"',
     "-c",
-    "model_providers.cli_manager_remote.name=CLI-Manager remote",
+    "model_providers.custom.name=CLI-Manager remote",
     "-c",
-    "model_providers.cli_manager_remote.base_url=https://provider.example.com/v1",
+    "model_providers.custom.base_url=https://provider.example.com/v1",
     "-c",
-    "model_providers.cli_manager_remote.env_key=CLI_MANAGER_TEST_API_KEY",
+    "model_providers.custom.env_key=CLI_MANAGER_TEST_API_KEY",
     "-c",
-    "model_providers.cli_manager_remote.wire_api=responses",
+    "model_providers.custom.wire_api=responses",
     "-c",
     'model_catalog_json="C:/Users/test/CLI Manager/cli-manager-model-catalog.json"',
     "-c",

--- a/src-tauri/src/codex_app_server_proxy.rs
+++ b/src-tauri/src/codex_app_server_proxy.rs
@@ -25,8 +25,11 @@ pub(crate) const CODEX_MODEL_OVERRIDE_ENV: &str = "CLI_MANAGER_CODEX_MODEL_OVERR
 pub(crate) const CODEX_MODEL_CATALOG_OVERRIDE_ENV: &str =
     "CLI_MANAGER_CODEX_MODEL_CATALOG_OVERRIDE";
 pub(crate) const CODEX_WIRE_API_OVERRIDE_ENV: &str = "CLI_MANAGER_CODEX_WIRE_API_OVERRIDE";
+pub(crate) const CODEX_PROVIDER_NAME_OVERRIDE_ENV: &str =
+    "CLI_MANAGER_CODEX_PROVIDER_NAME_OVERRIDE";
+pub(crate) const CODEX_PROFILE_NAME_ENV: &str = "CLI_MANAGER_CODEX_PROFILE_NAME";
+pub(crate) const CODEX_MODEL_PROVIDER_ENV: &str = "CLI_MANAGER_CODEX_MODEL_PROVIDER";
 pub(crate) const CODEX_SSH_LAUNCH_ENV: &str = "CLI_MANAGER_CODEX_SSH_LAUNCH";
-pub(crate) const CODEX_REMOTE_PROVIDER_NAME: &str = "cli_manager_remote";
 
 // A resumed Codex thread can legitimately exceed cc-connect's 10 MB scanner limit.
 // Keep a finite ceiling so a broken child cannot exhaust the host process indefinitely.
@@ -34,6 +37,7 @@ const MAX_PROTOCOL_LINE_BYTES: usize = 512 * 1024 * 1024;
 const STRICT_RESUME_ERROR_CODE: i64 = -32091;
 const SSH_HANDOFF_HOOK_QUEUE_CAPACITY: usize = 32;
 const LOCAL_HANDOFF_DELIVERY_INSTRUCTION: &str = "CLI-Manager remote handoff: deliver output files with `cc-connect send --file <absolute-path>` and output images with `cc-connect send --image <absolute-path>`.";
+const LOCAL_HANDOFF_DELIVERY_CONTEXT_KEY: &str = "cli-manager.remote-handoff.delivery";
 
 #[derive(Debug, Deserialize)]
 struct RpcProbe {
@@ -62,6 +66,8 @@ struct ResumeResult {
     #[serde(default)]
     model: String,
     #[serde(default)]
+    model_provider: String,
+    #[serde(default)]
     reasoning_effort: Option<String>,
     #[serde(default)]
     thread: ResumeThread,
@@ -71,6 +77,8 @@ struct ResumeResult {
 struct ResumeThread {
     #[serde(default)]
     id: String,
+    #[serde(default)]
+    model_provider: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -85,6 +93,7 @@ struct MinimalRpcError {
 struct PendingResume {
     requested_thread_id: String,
     expected_thread_id: Option<String>,
+    expected_model_provider: Option<String>,
 }
 
 enum ClientLineAction {
@@ -283,13 +292,20 @@ fn run_proxy(child_args: &[String]) -> Result<i32, String> {
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
-    let mut command = if let Some(ssh_launch) = ssh_launch.as_ref() {
-        command_from_ssh_launch(ssh_launch.build_launch(child_args)?)
+    let (mut command, expected_model_provider) = if let Some(ssh_launch) = ssh_launch.as_ref() {
+        (
+            command_from_ssh_launch(ssh_launch.build_launch(child_args)?),
+            None,
+        )
     } else {
         let launcher = codex_launcher_from_environment()?;
         let provider_overrides = CodexProviderOverrides::from_environment()?;
+        let expected_model_provider = provider_overrides.model_provider.clone();
         let child_args = build_codex_child_args(child_args, &provider_overrides)?;
-        codex_command(&launcher, &child_args)
+        (
+            codex_command(&launcher, &child_args),
+            expected_model_provider,
+        )
     };
     command
         .stdin(Stdio::piped())
@@ -319,6 +335,7 @@ fn run_proxy(child_args: &[String]) -> Result<i32, String> {
         if let Err(err) = forward_parent_input(
             child_stdin,
             expected_thread_id.as_deref(),
+            expected_model_provider.as_deref(),
             remote_work_dir.as_deref(),
             &input_pending,
             &input_output,
@@ -403,6 +420,9 @@ fn codex_launcher_from_environment() -> Result<PathBuf, String> {
 
 #[derive(Debug, Default, PartialEq, Eq)]
 struct CodexProviderOverrides {
+    profile_name: Option<String>,
+    model_provider: Option<String>,
+    provider_name: Option<String>,
     base_url: Option<String>,
     env_key: Option<String>,
     model: Option<String>,
@@ -413,6 +433,9 @@ struct CodexProviderOverrides {
 impl CodexProviderOverrides {
     fn from_environment() -> Result<Self, String> {
         Ok(Self {
+            profile_name: optional_unicode_env(CODEX_PROFILE_NAME_ENV)?,
+            model_provider: optional_unicode_env(CODEX_MODEL_PROVIDER_ENV)?,
+            provider_name: optional_unicode_env(CODEX_PROVIDER_NAME_OVERRIDE_ENV)?,
             base_url: optional_unicode_env(CODEX_BASE_URL_OVERRIDE_ENV)?,
             env_key: optional_unicode_env(CODEX_ENV_KEY_OVERRIDE_ENV)?,
             model: optional_unicode_env(CODEX_MODEL_OVERRIDE_ENV)?,
@@ -421,8 +444,11 @@ impl CodexProviderOverrides {
         })
     }
 
-    fn command_args(&self) -> Result<Vec<String>, String> {
-        let has_any = self.base_url.is_some()
+    fn command_args(&self, include_profile: bool) -> Result<Vec<String>, String> {
+        let has_any = self.profile_name.is_some()
+            || self.model_provider.is_some()
+            || self.provider_name.is_some()
+            || self.base_url.is_some()
             || self.env_key.is_some()
             || self.model.is_some()
             || self.model_catalog.is_some()
@@ -430,6 +456,14 @@ impl CodexProviderOverrides {
         if !has_any {
             return Ok(Vec::new());
         }
+        let model_provider = self
+            .model_provider
+            .as_ref()
+            .ok_or_else(|| "Codex model Provider ID is missing".to_string())?;
+        let provider_name = self
+            .provider_name
+            .as_ref()
+            .ok_or_else(|| "Codex Provider name override is missing".to_string())?;
         let base_url = self
             .base_url
             .as_ref()
@@ -446,11 +480,23 @@ impl CodexProviderOverrides {
             .model_catalog
             .as_ref()
             .ok_or_else(|| "Codex model catalog override is missing".to_string())?;
-        let mut args = vec![
+        let mut args = Vec::new();
+        if include_profile {
+            let profile_name = self
+                .profile_name
+                .as_ref()
+                .ok_or_else(|| "Codex Provider profile name is missing".to_string())?;
+            args.extend(["--profile".to_string(), profile_name.clone()]);
+        }
+        args.extend([
             "-c".to_string(),
-            format!("model_provider={CODEX_REMOTE_PROVIDER_NAME}"),
+            format!(
+                "model_provider={}",
+                serde_json::to_string(model_provider)
+                    .map_err(|err| format!("encode Codex model Provider ID failed: {err}"))?
+            ),
             "-c".to_string(),
-            format!("model_providers.{CODEX_REMOTE_PROVIDER_NAME}.name=CLI-Manager remote"),
+            provider_name.clone(),
             "-c".to_string(),
             base_url.clone(),
             "-c".to_string(),
@@ -459,7 +505,7 @@ impl CodexProviderOverrides {
             wire_api.clone(),
             "-c".to_string(),
             model_catalog.clone(),
-        ];
+        ]);
         if let Some(model) = self.model.as_ref() {
             args.extend(["-c".to_string(), model.clone()]);
         }
@@ -480,7 +526,10 @@ fn build_codex_child_args(
     child_args: &[String],
     overrides: &CodexProviderOverrides,
 ) -> Result<Vec<String>, String> {
-    let mut args = overrides.command_args()?;
+    // Codex rejects --profile for app-server, while runtime commands still use
+    // the generated profile. The complete -c overrides lock app-server to the
+    // registered Provider without relying on profile support.
+    let mut args = overrides.command_args(!is_app_server_command(child_args))?;
     args.extend_from_slice(child_args);
     Ok(args)
 }
@@ -514,6 +563,7 @@ fn codex_command(launcher: &Path, args: &[String]) -> Command {
 fn forward_parent_input(
     mut child_stdin: impl Write,
     expected_thread_id: Option<&str>,
+    expected_model_provider: Option<&str>,
     remote_work_dir: Option<&str>,
     pending: &Arc<Mutex<HashMap<String, PendingResume>>>,
     parent_output: &Arc<Mutex<io::Stdout>>,
@@ -532,6 +582,7 @@ fn forward_parent_input(
             inspect_client_line(
                 &line,
                 expected_thread_id,
+                expected_model_provider,
                 remote_work_dir,
                 &mut pending,
                 &mut delivery_instruction_pending,
@@ -579,6 +630,7 @@ fn forward_child_output(
 fn inspect_client_line(
     line: &[u8],
     expected_thread_id: Option<&str>,
+    expected_model_provider: Option<&str>,
     remote_work_dir: Option<&str>,
     pending: &mut HashMap<String, PendingResume>,
     delivery_instruction_pending: &mut bool,
@@ -595,7 +647,7 @@ fn inspect_client_line(
         && *delivery_instruction_pending
         && expected_thread_id.is_some()
         && remote_work_dir.is_none()
-        && prepend_local_handoff_delivery_instruction(&mut message)
+        && inject_local_handoff_delivery_context(&mut message)
     {
         *delivery_instruction_pending = false;
         return ClientLineAction::Forward(json_line(&message));
@@ -643,7 +695,7 @@ fn inspect_client_line(
         }
     }
     let mut request_changed = false;
-    if remote_work_dir.is_some() {
+    if remote_work_dir.is_some() || expected_model_provider.is_some() {
         let Some(params) = message.get_mut("params").and_then(Value::as_object_mut) else {
             return ClientLineAction::Reject(rpc_error_response(
                 &id,
@@ -657,6 +709,13 @@ fn inspect_client_line(
             );
             request_changed = true;
         }
+        if let Some(model_provider) = expected_model_provider {
+            params.insert(
+                "modelProvider".to_string(),
+                Value::String(model_provider.to_string()),
+            );
+            request_changed = true;
+        }
     }
     if let Some(key) = rpc_id_key(&id) {
         pending.insert(
@@ -664,6 +723,7 @@ fn inspect_client_line(
             PendingResume {
                 requested_thread_id,
                 expected_thread_id: expected_thread_id.map(str::to_string),
+                expected_model_provider: expected_model_provider.map(str::to_string),
             },
         );
     }
@@ -674,25 +734,38 @@ fn inspect_client_line(
     }
 }
 
-fn prepend_local_handoff_delivery_instruction(message: &mut Value) -> bool {
-    let Some(inputs) = message
-        .pointer_mut("/params/input")
-        .and_then(Value::as_array_mut)
-    else {
+fn inject_local_handoff_delivery_context(message: &mut Value) -> bool {
+    let has_text_input = message
+        .pointer("/params/input")
+        .and_then(Value::as_array)
+        .is_some_and(|inputs| {
+            inputs.iter().any(|input| {
+                input.get("type").and_then(Value::as_str) == Some("text")
+                    && input.get("text").is_some_and(Value::is_string)
+            })
+        });
+    if !has_text_input {
+        return false;
+    }
+    let Some(params) = message.get_mut("params").and_then(Value::as_object_mut) else {
         return false;
     };
-    let Some(text) = inputs.iter_mut().find_map(|input| {
-        if input.get("type").and_then(Value::as_str) != Some("text") {
-            return None;
-        }
-        input.get_mut("text").filter(|value| value.is_string())
-    }) else {
+    let additional_context = params
+        .entry("additionalContext".to_string())
+        .or_insert_with(|| Value::Object(Default::default()));
+    if additional_context.is_null() {
+        *additional_context = Value::Object(Default::default());
+    }
+    let Some(additional_context) = additional_context.as_object_mut() else {
         return false;
     };
-    let original = text.as_str().unwrap_or_default();
-    *text = Value::String(format!(
-        "{LOCAL_HANDOFF_DELIVERY_INSTRUCTION}\n\n{original}"
-    ));
+    additional_context.insert(
+        LOCAL_HANDOFF_DELIVERY_CONTEXT_KEY.to_string(),
+        json!({
+            "kind": "application",
+            "value": LOCAL_HANDOFF_DELIVERY_INSTRUCTION,
+        }),
+    );
     true
 }
 
@@ -806,6 +879,32 @@ fn compact_resume_response(payload: &[u8], fallback_id: &Value, resume: &Pending
             "CLI-Manager received an empty Codex thread ID while resuming".to_string(),
         );
     }
+    let resumed_model_provider = [
+        result.model_provider.trim(),
+        result.thread.model_provider.trim(),
+    ]
+    .into_iter()
+    .find(|value| !value.is_empty())
+    .unwrap_or_default()
+    .to_string();
+    if let Some(expected) = resume.expected_model_provider.as_deref() {
+        if resumed_model_provider.is_empty() {
+            return rpc_error_response(
+                response_id,
+                format!(
+                    "CLI-Manager could not verify the Codex Provider after resume: expected {expected}, but Codex returned no Provider ID"
+                ),
+            );
+        }
+        if resumed_model_provider != expected {
+            return rpc_error_response(
+                response_id,
+                format!(
+                    "CLI-Manager blocked a Codex Provider mismatch after resume: expected {expected}, received {resumed_model_provider}"
+                ),
+            );
+        }
+    }
     if let Some(expected) = resume.expected_thread_id.as_deref() {
         if result.thread.id != expected {
             return rpc_error_response(
@@ -824,8 +923,12 @@ fn compact_resume_response(payload: &[u8], fallback_id: &Value, resume: &Pending
         "result": {
             "cwd": result.cwd,
             "model": result.model,
+            "modelProvider": resumed_model_provider.clone(),
             "reasoningEffort": result.reasoning_effort,
-            "thread": { "id": result.thread.id },
+            "thread": {
+                "id": result.thread.id,
+                "modelProvider": resumed_model_provider,
+            },
         }
     }));
     if payload.len() > 10 * 1024 * 1024 {
@@ -961,7 +1064,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_overrides_are_inserted_before_app_server_without_secrets() {
+    fn app_server_provider_overrides_omit_runtime_only_profile() {
         let args = build_codex_child_args(
             &[
                 "app-server".to_string(),
@@ -969,12 +1072,17 @@ mod tests {
                 "stdio://".to_string(),
             ],
             &CodexProviderOverrides {
+                profile_name: Some("cli-manager-project-provider-123".to_string()),
+                model_provider: Some("custom".to_string()),
+                provider_name: Some(
+                    "model_providers.custom.name=CLI-Manager remote".to_string(),
+                ),
                 base_url: Some(
-                    "model_providers.cli_manager_remote.base_url=https://provider.example.com/v1"
+                    "model_providers.custom.base_url=https://provider.example.com/v1"
                         .to_string(),
                 ),
                 env_key: Some(
-                    "model_providers.cli_manager_remote.env_key=CLI_MANAGER_CODEX_PROVIDER_API_KEY"
+                    "model_providers.custom.env_key=CLI_MANAGER_CODEX_PROVIDER_API_KEY"
                         .to_string(),
                 ),
                 model: Some("model=gpt-5.4".to_string()),
@@ -982,7 +1090,7 @@ mod tests {
                     r#"model_catalog_json="C:/Users/test/CLI Manager/cli-manager-model-catalog.json""#
                         .to_string(),
                 ),
-                wire_api: Some("model_providers.cli_manager_remote.wire_api=responses".to_string()),
+                wire_api: Some("model_providers.custom.wire_api=responses".to_string()),
             },
         )
         .unwrap();
@@ -991,15 +1099,15 @@ mod tests {
             args,
             vec![
                 "-c",
-                "model_provider=cli_manager_remote",
+                "model_provider=\"custom\"",
                 "-c",
-                "model_providers.cli_manager_remote.name=CLI-Manager remote",
+                "model_providers.custom.name=CLI-Manager remote",
                 "-c",
-                "model_providers.cli_manager_remote.base_url=https://provider.example.com/v1",
+                "model_providers.custom.base_url=https://provider.example.com/v1",
                 "-c",
-                "model_providers.cli_manager_remote.env_key=CLI_MANAGER_CODEX_PROVIDER_API_KEY",
+                "model_providers.custom.env_key=CLI_MANAGER_CODEX_PROVIDER_API_KEY",
                 "-c",
-                "model_providers.cli_manager_remote.wire_api=responses",
+                "model_providers.custom.wire_api=responses",
                 "-c",
                 r#"model_catalog_json="C:/Users/test/CLI Manager/cli-manager-model-catalog.json""#,
                 "-c",
@@ -1010,6 +1118,50 @@ mod tests {
             ]
         );
         assert!(!args.iter().any(|arg| arg.contains("sk-provider-secret")));
+    }
+
+    #[test]
+    fn runtime_provider_overrides_keep_the_generated_profile() {
+        let args = build_codex_child_args(
+            &["resume".to_string(), "thread-original".to_string()],
+            &CodexProviderOverrides {
+                profile_name: Some("cli-manager-project-provider-123".to_string()),
+                model_provider: Some("custom".to_string()),
+                provider_name: Some(
+                    "model_providers.custom.name=CLI-Manager remote".to_string(),
+                ),
+                base_url: Some(
+                    "model_providers.custom.base_url=https://provider.example.com/v1"
+                        .to_string(),
+                ),
+                env_key: Some(
+                    "model_providers.custom.env_key=CLI_MANAGER_CODEX_PROVIDER_API_KEY"
+                        .to_string(),
+                ),
+                model: Some("model=gpt-5.4".to_string()),
+                model_catalog: Some(
+                    r#"model_catalog_json="C:/Users/test/CLI Manager/cli-manager-model-catalog.json""#
+                        .to_string(),
+                ),
+                wire_api: Some("model_providers.custom.wire_api=responses".to_string()),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            args.get(0..2),
+            Some(
+                [
+                    "--profile".to_string(),
+                    "cli-manager-project-provider-123".to_string(),
+                ]
+                .as_slice()
+            )
+        );
+        assert_eq!(
+            args.get(args.len().saturating_sub(2)..),
+            Some(["resume".to_string(), "thread-original".to_string()].as_slice())
+        );
     }
 
     #[test]
@@ -1038,12 +1190,13 @@ mod tests {
     #[test]
     fn partial_provider_overrides_are_rejected() {
         let error = CodexProviderOverrides {
-            base_url: Some(
-                "model_providers.cli_manager_remote.base_url=https://example.com".into(),
-            ),
+            profile_name: Some("cli-manager-project-provider-123".into()),
+            model_provider: Some("custom".into()),
+            provider_name: Some("model_providers.custom.name=CLI-Manager remote".into()),
+            base_url: Some("model_providers.custom.base_url=https://example.com".into()),
             ..CodexProviderOverrides::default()
         }
-        .command_args()
+        .command_args(false)
         .unwrap_err();
         assert!(error.contains("environment key"));
     }
@@ -1051,17 +1204,17 @@ mod tests {
     #[test]
     fn provider_overrides_require_the_managed_model_catalog() {
         let error = CodexProviderOverrides {
-            base_url: Some(
-                "model_providers.cli_manager_remote.base_url=https://example.com".into(),
-            ),
+            profile_name: Some("cli-manager-project-provider-123".into()),
+            model_provider: Some("custom".into()),
+            provider_name: Some("model_providers.custom.name=CLI-Manager remote".into()),
+            base_url: Some("model_providers.custom.base_url=https://example.com".into()),
             env_key: Some(
-                "model_providers.cli_manager_remote.env_key=CLI_MANAGER_CODEX_PROVIDER_API_KEY"
-                    .into(),
+                "model_providers.custom.env_key=CLI_MANAGER_CODEX_PROVIDER_API_KEY".into(),
             ),
-            wire_api: Some("model_providers.cli_manager_remote.wire_api=responses".into()),
+            wire_api: Some("model_providers.custom.wire_api=responses".into()),
             ..CodexProviderOverrides::default()
         }
-        .command_args()
+        .command_args(false)
         .unwrap_err();
         assert!(error.contains("model catalog"));
     }
@@ -1075,9 +1228,11 @@ mod tests {
             "result": {
                 "cwd": "F:\\repo",
                 "model": "gpt-5.4",
+                "modelProvider": "custom",
                 "reasoningEffort": "high",
                 "thread": {
                     "id": "thread-original",
+                    "modelProvider": "custom",
                     "turns": [{"items": [{"type": "message", "text": huge_history}]}]
                 }
             }
@@ -1088,6 +1243,7 @@ mod tests {
             PendingResume {
                 requested_thread_id: "thread-original".to_string(),
                 expected_thread_id: Some("thread-original".to_string()),
+                expected_model_provider: Some("custom".to_string()),
             },
         )]);
 
@@ -1097,8 +1253,73 @@ mod tests {
         assert_eq!(value["result"]["thread"]["id"], "thread-original");
         assert_eq!(value["result"]["cwd"], r"F:\repo");
         assert_eq!(value["result"]["model"], "gpt-5.4");
+        assert_eq!(value["result"]["modelProvider"], "custom");
         assert_eq!(value["result"]["reasoningEffort"], "high");
         assert!(value["result"]["thread"].get("turns").is_none());
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn resume_response_rejects_a_provider_mismatch_before_the_first_turn() {
+        let source = json_line(&json!({
+            "jsonrpc": "2.0",
+            "id": 15,
+            "result": {
+                "cwd": "F:\\repo",
+                "model": "gpt-5.4",
+                "modelProvider": "custom",
+                "thread": {
+                    "id": "thread-original",
+                    "modelProvider": "custom",
+                }
+            }
+        }));
+        let mut pending = HashMap::from([(
+            "15".to_string(),
+            PendingResume {
+                requested_thread_id: "thread-original".to_string(),
+                expected_thread_id: Some("thread-original".to_string()),
+                expected_model_provider: Some("cli_manager".to_string()),
+            },
+        )]);
+
+        let response = transform_server_line(&source, &mut pending).unwrap();
+        let response: Value = serde_json::from_slice(trim_line_ending(&response)).unwrap();
+        assert!(response.get("result").is_none());
+        assert!(response["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("Provider mismatch")));
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn resume_response_uses_the_effective_provider_over_stale_thread_metadata() {
+        let source = json_line(&json!({
+            "jsonrpc": "2.0",
+            "id": 16,
+            "result": {
+                "cwd": "F:\\repo",
+                "model": "gpt-5.4",
+                "modelProvider": "cli_manager",
+                "thread": {
+                    "id": "thread-original",
+                    "modelProvider": "custom",
+                }
+            }
+        }));
+        let mut pending = HashMap::from([(
+            "16".to_string(),
+            PendingResume {
+                requested_thread_id: "thread-original".to_string(),
+                expected_thread_id: Some("thread-original".to_string()),
+                expected_model_provider: Some("cli_manager".to_string()),
+            },
+        )]);
+
+        let response = transform_server_line(&source, &mut pending).unwrap();
+        let response: Value = serde_json::from_slice(trim_line_ending(&response)).unwrap();
+        assert_eq!(response["result"]["modelProvider"], "cli_manager");
+        assert_eq!(response["result"]["thread"]["modelProvider"], "cli_manager");
         assert!(pending.is_empty());
     }
 
@@ -1111,6 +1332,7 @@ mod tests {
         let ClientLineAction::Reject(response) = inspect_client_line(
             drifted,
             Some("thread-original"),
+            None,
             None,
             &mut pending,
             &mut delivery_instruction_pending,
@@ -1132,6 +1354,7 @@ mod tests {
                 fresh,
                 Some("thread-original"),
                 None,
+                None,
                 &mut pending,
                 &mut delivery_instruction_pending,
             ),
@@ -1150,6 +1373,7 @@ mod tests {
                 request,
                 Some("thread-original"),
                 None,
+                None,
                 &mut pending,
                 &mut delivery_instruction_pending,
             ),
@@ -1164,7 +1388,7 @@ mod tests {
     }
 
     #[test]
-    fn local_handoff_resume_does_not_inject_synthetic_provider() {
+    fn local_handoff_resume_injects_registered_provider() {
         let mut pending = HashMap::new();
         let mut delivery_instruction_pending = false;
         let request = br#"{"jsonrpc":"2.0","id":14,"method":"thread/resume","params":{"threadId":"thread-original"}}
@@ -1172,6 +1396,7 @@ mod tests {
         let ClientLineAction::Forward(forwarded) = inspect_client_line(
             request,
             Some("thread-original"),
+            Some("custom"),
             None,
             &mut pending,
             &mut delivery_instruction_pending,
@@ -1179,7 +1404,7 @@ mod tests {
             panic!("managed local resume must be forwarded");
         };
         let forwarded: Value = serde_json::from_slice(trim_line_ending(&forwarded)).unwrap();
-        assert!(forwarded["params"].get("modelProvider").is_none());
+        assert_eq!(forwarded["params"]["modelProvider"], "custom");
         assert_eq!(forwarded["params"]["threadId"], "thread-original");
         assert!(pending.contains_key("14"));
     }
@@ -1193,6 +1418,7 @@ mod tests {
         let ClientLineAction::Forward(forwarded) = inspect_client_line(
             request,
             Some("thread-original"),
+            None,
             Some("/srv/project"),
             &mut pending,
             &mut delivery_instruction_pending,
@@ -1205,14 +1431,15 @@ mod tests {
     }
 
     #[test]
-    fn local_managed_resume_injects_delivery_instruction_only_once() {
+    fn local_managed_turn_injects_delivery_context_without_changing_user_text() {
         let mut pending = HashMap::new();
         let mut delivery_instruction_pending = true;
-        let first = br#"{"jsonrpc":"2.0","id":9,"method":"turn/start","params":{"threadId":"thread-original","input":[{"type":"localImage","path":"C:\\tmp\\source.png"},{"type":"text","text":"Create the report"}]}}
+        let first = br#"{"jsonrpc":"2.0","id":9,"method":"turn/start","params":{"threadId":"thread-original","input":[{"type":"localImage","path":"C:\\tmp\\source.png"},{"type":"text","text":"Create the report"}],"additionalContext":{"cc-connect":{"kind":"application","value":"existing"}}}}
 "#;
         let ClientLineAction::Forward(first) = inspect_client_line(
             first,
             Some("thread-original"),
+            Some("custom"),
             None,
             &mut pending,
             &mut delivery_instruction_pending,
@@ -1221,9 +1448,18 @@ mod tests {
         };
         let first: Value = serde_json::from_slice(trim_line_ending(&first)).unwrap();
         assert_eq!(first["params"]["input"][0]["path"], r"C:\tmp\source.png");
+        assert_eq!(first["params"]["input"][1]["text"], "Create the report");
         assert_eq!(
-            first["params"]["input"][1]["text"],
-            format!("{LOCAL_HANDOFF_DELIVERY_INSTRUCTION}\n\nCreate the report")
+            first["params"]["additionalContext"][LOCAL_HANDOFF_DELIVERY_CONTEXT_KEY]["kind"],
+            "application"
+        );
+        assert_eq!(
+            first["params"]["additionalContext"][LOCAL_HANDOFF_DELIVERY_CONTEXT_KEY]["value"],
+            LOCAL_HANDOFF_DELIVERY_INSTRUCTION
+        );
+        assert_eq!(
+            first["params"]["additionalContext"]["cc-connect"]["value"],
+            "existing"
         );
         assert!(!delivery_instruction_pending);
 
@@ -1232,6 +1468,7 @@ mod tests {
         let ClientLineAction::Forward(forwarded) = inspect_client_line(
             second,
             Some("thread-original"),
+            Some("custom"),
             None,
             &mut pending,
             &mut delivery_instruction_pending,
@@ -1250,6 +1487,7 @@ mod tests {
         let ClientLineAction::Forward(ssh_forwarded) = inspect_client_line(
             request,
             Some("thread-original"),
+            None,
             Some("/srv/project"),
             &mut pending,
             &mut ssh_instruction_pending,
@@ -1262,6 +1500,7 @@ mod tests {
         let mut unmanaged_instruction_pending = true;
         let ClientLineAction::Forward(unmanaged_forwarded) = inspect_client_line(
             request,
+            None,
             None,
             None,
             &mut pending,
@@ -1282,6 +1521,7 @@ mod tests {
         let ClientLineAction::Forward(forwarded) = inspect_client_line(
             image_only,
             Some("thread-original"),
+            Some("custom"),
             None,
             &mut pending,
             &mut delivery_instruction_pending,
@@ -1296,6 +1536,7 @@ mod tests {
         let ClientLineAction::Forward(forwarded) = inspect_client_line(
             text_turn,
             Some("thread-original"),
+            Some("custom"),
             None,
             &mut pending,
             &mut delivery_instruction_pending,
@@ -1303,9 +1544,10 @@ mod tests {
             panic!("text turn must be forwarded");
         };
         let forwarded: Value = serde_json::from_slice(trim_line_ending(&forwarded)).unwrap();
+        assert_eq!(forwarded["params"]["input"][0]["text"], "Now create it");
         assert_eq!(
-            forwarded["params"]["input"][0]["text"],
-            format!("{LOCAL_HANDOFF_DELIVERY_INSTRUCTION}\n\nNow create it")
+            forwarded["params"]["additionalContext"][LOCAL_HANDOFF_DELIVERY_CONTEXT_KEY]["value"],
+            LOCAL_HANDOFF_DELIVERY_INSTRUCTION
         );
         assert!(!delivery_instruction_pending);
     }

--- a/src-tauri/src/commands/cc_connect.rs
+++ b/src-tauri/src/commands/cc_connect.rs
@@ -2,9 +2,9 @@
 use crate::codex_app_server_proxy::HELPER_SUBCOMMAND as CODEX_PROXY_SUBCOMMAND;
 use crate::codex_app_server_proxy::{
     SshCodexLaunch, CODEX_BASE_URL_OVERRIDE_ENV, CODEX_ENV_KEY_OVERRIDE_ENV, CODEX_LAUNCHER_ENV,
-    CODEX_MODEL_CATALOG_OVERRIDE_ENV, CODEX_MODEL_OVERRIDE_ENV, CODEX_REMOTE_PROVIDER_NAME,
-    CODEX_SSH_LAUNCH_ENV, CODEX_WIRE_API_OVERRIDE_ENV, EXPECTED_SESSION_ID_ENV,
-    PROXY_EXECUTABLE_ENV,
+    CODEX_MODEL_CATALOG_OVERRIDE_ENV, CODEX_MODEL_OVERRIDE_ENV, CODEX_MODEL_PROVIDER_ENV,
+    CODEX_PROFILE_NAME_ENV, CODEX_PROVIDER_NAME_OVERRIDE_ENV, CODEX_SSH_LAUNCH_ENV,
+    CODEX_WIRE_API_OVERRIDE_ENV, EXPECTED_SESSION_ID_ENV, PROXY_EXECUTABLE_ENV,
 };
 #[cfg(target_os = "windows")]
 use crate::process_job::ChildJob;
@@ -1251,6 +1251,25 @@ fn build_managed_config_with_codex(
                 .and_then(|provider| provider.model.clone())
         })
         .flatten();
+    let mut agent_environment = [
+        (TELEGRAM_TOKEN_ENV.to_string(), String::new()),
+        (FEISHU_APP_ID_ENV.to_string(), String::new()),
+        (FEISHU_APP_SECRET_ENV.to_string(), String::new()),
+        (WEIXIN_TOKEN_ENV.to_string(), String::new()),
+        (WECOM_BOT_ID_ENV.to_string(), String::new()),
+        (WECOM_BOT_SECRET_ENV.to_string(), String::new()),
+    ]
+    .into_iter()
+    .collect::<BTreeMap<_, _>>();
+    if let Some(provider) = codex_launch.and_then(|launch| launch.provider.as_ref()) {
+        // cc-connect builds the Codex child environment from this map. Keep the
+        // credential in the managed process environment and reference it here,
+        // so the generated config never persists the secret itself.
+        agent_environment.insert(
+            provider.env_key.clone(),
+            format!("${{{}}}", provider.env_key),
+        );
+    }
     Ok(ManagedConfig {
         data_dir: config_path_value(&data_dir()?),
         language: match profile.language {
@@ -1326,19 +1345,7 @@ fn build_managed_config_with_codex(
                     app_server_url: profile.agent.app_server_url().map(str::to_string),
                     model: active_model,
                     codex_home,
-                    // cc-connect resolves platform placeholders in its own process,
-                    // then MergeEnv lets these empty values override inheritance into
-                    // Claude/Codex child processes.
-                    env: [
-                        (TELEGRAM_TOKEN_ENV.to_string(), String::new()),
-                        (FEISHU_APP_ID_ENV.to_string(), String::new()),
-                        (FEISHU_APP_SECRET_ENV.to_string(), String::new()),
-                        (WEIXIN_TOKEN_ENV.to_string(), String::new()),
-                        (WECOM_BOT_ID_ENV.to_string(), String::new()),
-                        (WECOM_BOT_SECRET_ENV.to_string(), String::new()),
-                    ]
-                    .into_iter()
-                    .collect(),
+                    env: agent_environment,
                 },
             },
             platforms,
@@ -2365,6 +2372,9 @@ fn user_home_dir() -> Option<PathBuf> {
 
 struct RemoteCodexProviderLaunch {
     name: String,
+    profile_name: String,
+    model_provider: String,
+    provider_name_override: String,
     model: Option<String>,
     models: Vec<String>,
     base_url_override: String,
@@ -2453,7 +2463,7 @@ fn resolve_codex_launcher_from_path(
 #[cfg(not(target_os = "windows"))]
 fn codex_profile_wrapper_payload() -> String {
     format!(
-        "#!/bin/sh\nif [ -n \"${{{CODEX_SSH_LAUNCH_ENV}:-}}\" ]; then\n  exec \"${PROXY_EXECUTABLE_ENV}\" {CODEX_PROXY_SUBCOMMAND} \"$@\"\nfi\nif [ \"${{1:-}}\" = \"app-server\" ]; then\n  exec \"${PROXY_EXECUTABLE_ENV}\" {CODEX_PROXY_SUBCOMMAND} \"$@\"\nfi\nif [ -z \"${{{CODEX_BASE_URL_OVERRIDE_ENV}:-}}\" ]; then\n  exec \"${CODEX_LAUNCHER_ENV}\" \"$@\"\nfi\nif [ -n \"${{{CODEX_MODEL_OVERRIDE_ENV}:-}}\" ]; then\n  exec \"${CODEX_LAUNCHER_ENV}\" -c \"model_provider={CODEX_REMOTE_PROVIDER_NAME}\" -c \"model_providers.{CODEX_REMOTE_PROVIDER_NAME}.name=CLI-Manager remote\" -c \"${CODEX_BASE_URL_OVERRIDE_ENV}\" -c \"${CODEX_ENV_KEY_OVERRIDE_ENV}\" -c \"${CODEX_WIRE_API_OVERRIDE_ENV}\" -c \"${CODEX_MODEL_CATALOG_OVERRIDE_ENV}\" -c \"${CODEX_MODEL_OVERRIDE_ENV}\" \"$@\"\nelse\n  exec \"${CODEX_LAUNCHER_ENV}\" -c \"model_provider={CODEX_REMOTE_PROVIDER_NAME}\" -c \"model_providers.{CODEX_REMOTE_PROVIDER_NAME}.name=CLI-Manager remote\" -c \"${CODEX_BASE_URL_OVERRIDE_ENV}\" -c \"${CODEX_ENV_KEY_OVERRIDE_ENV}\" -c \"${CODEX_WIRE_API_OVERRIDE_ENV}\" -c \"${CODEX_MODEL_CATALOG_OVERRIDE_ENV}\" \"$@\"\nfi\n"
+        "#!/bin/sh\nif [ -n \"${{{CODEX_SSH_LAUNCH_ENV}:-}}\" ]; then\n  exec \"${PROXY_EXECUTABLE_ENV}\" {CODEX_PROXY_SUBCOMMAND} \"$@\"\nfi\nif [ \"${{1:-}}\" = \"app-server\" ]; then\n  exec \"${PROXY_EXECUTABLE_ENV}\" {CODEX_PROXY_SUBCOMMAND} \"$@\"\nfi\nif [ -z \"${{{CODEX_BASE_URL_OVERRIDE_ENV}:-}}\" ]; then\n  exec \"${CODEX_LAUNCHER_ENV}\" \"$@\"\nfi\nif [ -n \"${{{CODEX_MODEL_OVERRIDE_ENV}:-}}\" ]; then\n  exec \"${CODEX_LAUNCHER_ENV}\" --profile \"${CODEX_PROFILE_NAME_ENV}\" -c \"${CODEX_BASE_URL_OVERRIDE_ENV}\" -c \"${CODEX_ENV_KEY_OVERRIDE_ENV}\" -c \"${CODEX_WIRE_API_OVERRIDE_ENV}\" -c \"${CODEX_MODEL_CATALOG_OVERRIDE_ENV}\" -c \"${CODEX_MODEL_OVERRIDE_ENV}\" \"$@\"\nelse\n  exec \"${CODEX_LAUNCHER_ENV}\" --profile \"${CODEX_PROFILE_NAME_ENV}\" -c \"${CODEX_BASE_URL_OVERRIDE_ENV}\" -c \"${CODEX_ENV_KEY_OVERRIDE_ENV}\" -c \"${CODEX_WIRE_API_OVERRIDE_ENV}\" -c \"${CODEX_MODEL_CATALOG_OVERRIDE_ENV}\" \"$@\"\nfi\n"
     )
 }
 
@@ -2473,7 +2483,24 @@ fn codex_wrapper_override(key: &str, value: &str) -> Result<String, String> {
     Ok(format!("{key}={value}"))
 }
 
-fn codex_base_url_override(value: &str) -> Result<String, String> {
+fn codex_provider_override_key(model_provider: &str, field: &str) -> Result<String, String> {
+    let model_provider = model_provider.trim();
+    if model_provider.is_empty() || model_provider.chars().any(char::is_control) {
+        return Err("Codex model Provider ID is invalid".to_string());
+    }
+    let segment = if model_provider
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-'))
+    {
+        model_provider.to_string()
+    } else {
+        serde_json::to_string(model_provider)
+            .map_err(|err| format!("encode Codex model Provider ID failed: {err}"))?
+    };
+    Ok(format!("model_providers.{segment}.{field}"))
+}
+
+fn codex_base_url_override(model_provider: &str, value: &str) -> Result<String, String> {
     let value = value.trim();
     let url =
         reqwest::Url::parse(value).map_err(|_| "Codex Provider base URL is invalid".to_string())?;
@@ -2481,12 +2508,12 @@ fn codex_base_url_override(value: &str) -> Result<String, String> {
         return Err("Codex Provider base URL must use HTTP or HTTPS".to_string());
     }
     codex_wrapper_override(
-        &format!("model_providers.{CODEX_REMOTE_PROVIDER_NAME}.base_url"),
+        &codex_provider_override_key(model_provider, "base_url")?,
         value,
     )
 }
 
-fn codex_env_key_override(value: &str) -> Result<String, String> {
+fn codex_env_key_override(model_provider: &str, value: &str) -> Result<String, String> {
     let value = value.trim();
     let mut chars = value.chars();
     if !chars
@@ -2497,18 +2524,18 @@ fn codex_env_key_override(value: &str) -> Result<String, String> {
         return Err("Codex Provider environment key is invalid".to_string());
     }
     codex_wrapper_override(
-        &format!("model_providers.{CODEX_REMOTE_PROVIDER_NAME}.env_key"),
+        &codex_provider_override_key(model_provider, "env_key")?,
         value,
     )
 }
 
-fn codex_wire_api_override(value: Option<&str>) -> Result<String, String> {
+fn codex_wire_api_override(model_provider: &str, value: Option<&str>) -> Result<String, String> {
     let value = value
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or("responses");
     codex_wrapper_override(
-        &format!("model_providers.{CODEX_REMOTE_PROVIDER_NAME}.wire_api"),
+        &codex_provider_override_key(model_provider, "wire_api")?,
         value,
     )
 }
@@ -2880,6 +2907,10 @@ fn prepare_remote_codex_launch(
     let ssh_launch = (project.environment_type == "ssh")
         .then(|| load_ssh_codex_launch(project))
         .transpose()?;
+    let codex_home = ssh_launch
+        .is_none()
+        .then(|| codex_config_dir(profile))
+        .transpose()?;
     let provider = match (ssh_launch.is_none(), project.codex_provider_id.as_deref()) {
         (true, Some(provider_id)) => {
             let query_runtime = tokio::runtime::Builder::new_current_thread()
@@ -2888,6 +2919,12 @@ fn prepare_remote_codex_launch(
                 .map_err(|err| format!("create provider query runtime failed: {err}"))?;
             let runtime = query_runtime.block_on(
                 crate::provider::runtime::load_codex_runtime_config(provider_id),
+            )?;
+            crate::provider::runtime::write_codex_profile_to_dir(
+                codex_home.as_deref().ok_or_else(|| {
+                    "Codex home is unavailable for the registered Provider".to_string()
+                })?,
+                &runtime.profile,
             )?;
             let proxy = resolve_proxy_url_if_enabled(
                 profile.proxy_enabled,
@@ -2908,6 +2945,8 @@ fn prepare_remote_codex_launch(
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
                 .map(str::to_string);
+            let profile_name = runtime.profile.profile_name.clone();
+            let model_provider = runtime.profile.model_provider.clone();
             Some(RemoteCodexProviderLaunch {
                 name: project
                     .provider_name
@@ -2915,12 +2954,21 @@ fn prepare_remote_codex_launch(
                     .map(single_line)
                     .filter(|name| !name.is_empty())
                     .unwrap_or_else(|| provider_id.to_string()),
+                profile_name,
+                model_provider: model_provider.clone(),
+                provider_name_override: codex_wrapper_override(
+                    &codex_provider_override_key(&model_provider, "name")?,
+                    "CLI-Manager remote",
+                )?,
                 models: normalize_managed_codex_models(model.as_deref(), discovered_models),
                 model: model.clone(),
-                base_url_override: codex_base_url_override(&runtime.base_url)?,
-                env_key_override: codex_env_key_override(&runtime.env_key)?,
+                base_url_override: codex_base_url_override(&model_provider, &runtime.base_url)?,
+                env_key_override: codex_env_key_override(&model_provider, &runtime.env_key)?,
                 model_override: codex_model_override(model.as_deref())?,
-                wire_api_override: codex_wire_api_override(runtime.wire_api.as_deref())?,
+                wire_api_override: codex_wire_api_override(
+                    &model_provider,
+                    runtime.wire_api.as_deref(),
+                )?,
                 env_key: runtime.env_key,
                 secret: runtime.secret_value,
             })
@@ -2931,10 +2979,6 @@ fn prepare_remote_codex_launch(
     if provider.is_none() && ssh_launch.is_none() {
         return Ok(None);
     }
-    let codex_home = ssh_launch
-        .is_none()
-        .then(|| codex_config_dir(profile))
-        .transpose()?;
     let discovery_codex_home = match provider.as_ref() {
         Some(provider) => {
             let path = remote_manager_dir()?.join("codex-model-discovery");
@@ -3023,6 +3067,12 @@ fn apply_remote_codex_launch_environment(
                 .ok_or_else(|| "Codex model discovery directory is missing".to_string())
                 .and_then(codex_model_catalog_override)?;
             command
+                .env(CODEX_PROFILE_NAME_ENV, &provider.profile_name)
+                .env(CODEX_MODEL_PROVIDER_ENV, &provider.model_provider)
+                .env(
+                    CODEX_PROVIDER_NAME_OVERRIDE_ENV,
+                    &provider.provider_name_override,
+                )
                 .env(CODEX_BASE_URL_OVERRIDE_ENV, &provider.base_url_override)
                 .env(CODEX_ENV_KEY_OVERRIDE_ENV, &provider.env_key_override)
                 .env(CODEX_MODEL_CATALOG_OVERRIDE_ENV, model_catalog_override)
@@ -3038,6 +3088,9 @@ fn apply_remote_codex_launch_environment(
         }
         None => {
             command
+                .env_remove(CODEX_PROFILE_NAME_ENV)
+                .env_remove(CODEX_MODEL_PROVIDER_ENV)
+                .env_remove(CODEX_PROVIDER_NAME_OVERRIDE_ENV)
                 .env_remove(CODEX_BASE_URL_OVERRIDE_ENV)
                 .env_remove(CODEX_ENV_KEY_OVERRIDE_ENV)
                 .env_remove(CODEX_MODEL_CATALOG_OVERRIDE_ENV)
@@ -6381,16 +6434,17 @@ allow_from = ""
     fn sample_remote_codex_launch(provider: bool) -> RemoteCodexLaunch {
         let provider = provider.then(|| RemoteCodexProviderLaunch {
             name: "Project Provider".to_string(),
+            profile_name: "cli-manager-project-provider-123".to_string(),
+            model_provider: "custom".to_string(),
+            provider_name_override: "model_providers.custom.name=CLI-Manager remote".to_string(),
             model: Some("gpt-5.4".to_string()),
             models: vec!["gpt-5.4".to_string(), "gpt-5.3-codex".to_string()],
-            base_url_override:
-                "model_providers.cli_manager_remote.base_url=https://provider.example.com/v1"
-                    .to_string(),
-            env_key_override:
-                "model_providers.cli_manager_remote.env_key=CLI_MANAGER_CODEX_PROVIDER_API_KEY"
-                    .to_string(),
+            base_url_override: "model_providers.custom.base_url=https://provider.example.com/v1"
+                .to_string(),
+            env_key_override: "model_providers.custom.env_key=CLI_MANAGER_CODEX_PROVIDER_API_KEY"
+                .to_string(),
             model_override: Some("model=gpt-5.4".to_string()),
-            wire_api_override: "model_providers.cli_manager_remote.wire_api=responses".to_string(),
+            wire_api_override: "model_providers.custom.wire_api=responses".to_string(),
             env_key: "CLI_MANAGER_CODEX_PROVIDER_API_KEY".to_string(),
             secret: "sk-provider-secret".to_string(),
         });
@@ -6409,7 +6463,7 @@ allow_from = ""
     }
 
     #[test]
-    fn managed_codex_config_keeps_provider_runtime_out_of_cc_connect_config() {
+    fn managed_codex_config_forwards_provider_key_without_persisting_secret() {
         let project = tempfile::tempdir().unwrap();
         let mut profile = sample_profile(project.path());
         profile.agent = CcConnectAgent::Codex;
@@ -6436,10 +6490,13 @@ allow_from = ""
             .unwrap()
             .contains_key("provider"));
         assert!(!agent.as_table().unwrap().contains_key("providers"));
+        assert_eq!(
+            agent["options"]["env"]["CLI_MANAGER_CODEX_PROVIDER_API_KEY"].as_str(),
+            Some("${CLI_MANAGER_CODEX_PROVIDER_API_KEY}")
+        );
         for secret in [
             "sk-provider-secret",
             "https://provider.example.com/v1",
-            "CLI_MANAGER_CODEX_PROVIDER_API_KEY",
             "Project Provider",
         ] {
             assert!(!raw.contains(secret));
@@ -6563,8 +6620,21 @@ allow_from = ""
         assert_eq!(
             environment.get(CODEX_BASE_URL_OVERRIDE_ENV),
             Some(&Some(
-                "model_providers.cli_manager_remote.base_url=https://provider.example.com/v1"
-                    .to_string()
+                "model_providers.custom.base_url=https://provider.example.com/v1".to_string()
+            ))
+        );
+        assert_eq!(
+            environment.get(CODEX_PROFILE_NAME_ENV),
+            Some(&Some("cli-manager-project-provider-123".to_string()))
+        );
+        assert_eq!(
+            environment.get(CODEX_MODEL_PROVIDER_ENV),
+            Some(&Some("custom".to_string()))
+        );
+        assert_eq!(
+            environment.get(CODEX_PROVIDER_NAME_OVERRIDE_ENV),
+            Some(&Some(
+                "model_providers.custom.name=CLI-Manager remote".to_string()
             ))
         );
         assert_eq!(
@@ -6611,6 +6681,9 @@ allow_from = ""
             })
             .collect::<BTreeMap<_, _>>();
         for key in [
+            CODEX_PROFILE_NAME_ENV,
+            CODEX_MODEL_PROVIDER_ENV,
+            CODEX_PROVIDER_NAME_OVERRIDE_ENV,
             CODEX_BASE_URL_OVERRIDE_ENV,
             CODEX_ENV_KEY_OVERRIDE_ENV,
             CODEX_MODEL_CATALOG_OVERRIDE_ENV,
@@ -6643,16 +6716,19 @@ allow_from = ""
     #[test]
     fn codex_app_server_overrides_reject_command_injection_characters() {
         assert_eq!(
-            codex_base_url_override("https://provider.example.com/v1").unwrap(),
-            "model_providers.cli_manager_remote.base_url=https://provider.example.com/v1"
+            codex_base_url_override("custom", "https://provider.example.com/v1").unwrap(),
+            "model_providers.custom.base_url=https://provider.example.com/v1"
         );
-        assert!(codex_base_url_override("https://provider.example.com/v1?x=1&whoami").is_err());
-        assert!(codex_base_url_override("file:///tmp/provider").is_err());
-        assert!(codex_env_key_override("OPENAI_API_KEY").is_ok());
-        assert!(codex_env_key_override("OPENAI_API_KEY & whoami").is_err());
+        assert!(
+            codex_base_url_override("custom", "https://provider.example.com/v1?x=1&whoami")
+                .is_err()
+        );
+        assert!(codex_base_url_override("custom", "file:///tmp/provider").is_err());
+        assert!(codex_env_key_override("custom", "OPENAI_API_KEY").is_ok());
+        assert!(codex_env_key_override("custom", "OPENAI_API_KEY & whoami").is_err());
         assert_eq!(
-            codex_wire_api_override(None).unwrap(),
-            "model_providers.cli_manager_remote.wire_api=responses"
+            codex_wire_api_override("custom", None).unwrap(),
+            "model_providers.custom.wire_api=responses"
         );
         assert_eq!(codex_model_override(None).unwrap(), None);
         assert!(codex_model_override(Some("gpt-5.4\" & whoami")).is_err());
@@ -7043,6 +7119,9 @@ allow_from = ""
         .unwrap();
         fs::write(&config_path, toml::to_string_pretty(&config).unwrap()).unwrap();
         format_and_check_config_syntax(Path::new(&binary), &config_path).unwrap();
+        let formatted = fs::read_to_string(&config_path).unwrap();
+        assert!(formatted.contains("${CLI_MANAGER_CODEX_PROVIDER_API_KEY}"));
+        assert!(!formatted.contains("sk-provider-secret"));
         profile.platforms.clear();
         profile.platform = CcConnectPlatform::Weixin;
         profile.allow_from = "authorization-pending@im.wechat".to_string();

--- a/src-tauri/src/provider/runtime.rs
+++ b/src-tauri/src/provider/runtime.rs
@@ -2,9 +2,34 @@ use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 use sqlx::Row;
 
-use super::{open_connection, repository};
+use super::{global, open_connection, repository};
+use std::fs;
+use std::path::Path;
+use toml_edit::DocumentMut;
+
+pub(crate) struct CodexProviderProfile {
+    pub(crate) profile_name: String,
+    pub(crate) model_provider: String,
+    pub(crate) profile_text: String,
+}
+
+impl CodexProviderProfile {
+    pub(crate) fn with_env_key(&self, env_key: &str) -> Result<Self, String> {
+        let mut document = self
+            .profile_text
+            .parse::<DocumentMut>()
+            .map_err(|_| "provider_config_invalid".to_string())?;
+        set_profile_env_key(&mut document, &self.model_provider, env_key)?;
+        Ok(Self {
+            profile_name: self.profile_name.clone(),
+            model_provider: self.model_provider.clone(),
+            profile_text: document.to_string(),
+        })
+    }
+}
 
 pub(crate) struct CodexProviderRuntimeConfig {
+    pub(crate) profile: CodexProviderProfile,
     pub(crate) env_key: String,
     pub(crate) secret_value: String,
     pub(crate) base_url: String,
@@ -148,13 +173,116 @@ pub(crate) fn parse_runtime_config(
         .and_then(|config| find_selected_provider_env_key(config, &secret_value))
         .unwrap_or(generated_env_key);
 
+    let profile = materialize_codex_profile(
+        provider_id,
+        &parsed,
+        &env_key,
+        &base_url,
+        model.as_deref(),
+        wire_api.as_deref(),
+    )?;
+
     Ok(CodexProviderRuntimeConfig {
+        profile,
         env_key,
         secret_value,
         base_url,
         model,
         wire_api,
     })
+}
+
+fn materialize_codex_profile(
+    provider_id: &str,
+    effective: &Value,
+    env_key: &str,
+    base_url: &str,
+    model: Option<&str>,
+    wire_api: Option<&str>,
+) -> Result<CodexProviderProfile, String> {
+    let mut normalized = effective.clone();
+    let root = normalized
+        .as_object_mut()
+        .ok_or_else(|| "provider_config_invalid".to_string())?;
+    root.insert("base_url".to_string(), Value::String(base_url.to_string()));
+    if let Some(model) = model {
+        root.insert("model".to_string(), Value::String(model.to_string()));
+    }
+    let (bytes, _) = global::materialize_codex_config(None, &normalized)?;
+    let mut document = String::from_utf8(bytes)
+        .map_err(|_| "provider_config_invalid".to_string())?
+        .parse::<DocumentMut>()
+        .map_err(|_| "provider_config_invalid".to_string())?;
+    let model_provider = document
+        .get("model_provider")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "provider_config_invalid: missing_codex_model_provider".to_string())?
+        .to_string();
+    set_profile_env_key(&mut document, &model_provider, env_key)?;
+    if let Some(wire_api) = wire_api.map(str::trim).filter(|value| !value.is_empty()) {
+        let provider = document
+            .get_mut("model_providers")
+            .and_then(|value| value.as_table_mut())
+            .and_then(|providers| providers.get_mut(&model_provider))
+            .and_then(|value| value.as_table_mut())
+            .ok_or_else(|| "provider_config_invalid: missing_codex_model_provider".to_string())?;
+        provider.insert("wire_api", toml_edit::value(wire_api));
+    }
+
+    Ok(CodexProviderProfile {
+        profile_name: codex_profile_name(provider_id),
+        model_provider,
+        profile_text: document.to_string(),
+    })
+}
+
+fn set_profile_env_key(
+    document: &mut DocumentMut,
+    model_provider: &str,
+    env_key: &str,
+) -> Result<(), String> {
+    let provider = document
+        .get_mut("model_providers")
+        .and_then(|value| value.as_table_mut())
+        .and_then(|providers| providers.get_mut(model_provider))
+        .and_then(|value| value.as_table_mut())
+        .ok_or_else(|| "provider_config_invalid: missing_codex_model_provider".to_string())?;
+    provider.insert("env_key", toml_edit::value(env_key));
+    Ok(())
+}
+
+pub(crate) fn write_codex_profile_to_dir(
+    codex_dir: &Path,
+    profile: &CodexProviderProfile,
+) -> Result<(), String> {
+    fs::create_dir_all(codex_dir).map_err(|err| format!("profile_write_failed: {err}"))?;
+    fs::write(
+        codex_dir.join(format!("{}.config.toml", profile.profile_name)),
+        &profile.profile_text,
+    )
+    .map_err(|err| format!("profile_write_failed: {err}"))
+}
+
+pub(crate) fn codex_profile_name(provider_id: &str) -> String {
+    let mut slug = provider_id
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+                ch.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    slug = slug.trim_matches('-').chars().take(40).collect();
+    if slug.is_empty() {
+        slug = "provider".to_string();
+    }
+    let digest = Sha256::digest(provider_id.as_bytes());
+    let hash = format!("{digest:x}");
+    format!("cli-manager-{}-{}", slug, &hash[..10])
 }
 
 fn env_value_text(value: &Value) -> String {
@@ -426,6 +554,16 @@ mod tests {
         assert_eq!(runtime.wire_api.as_deref(), Some("responses"));
         assert_eq!(runtime.env_key, "OPENAI_API_KEY");
         assert_eq!(runtime.secret_value, "sk-secret");
+        assert_eq!(runtime.profile.model_provider, "cloud");
+        assert!(runtime
+            .profile
+            .profile_text
+            .contains("base_url = \"https://api.example.com/v1\""));
+        assert!(runtime
+            .profile
+            .profile_text
+            .contains("env_key = \"OPENAI_API_KEY\""));
+        assert!(!runtime.profile.profile_text.contains("sk-secret"));
     }
 
     #[test]
@@ -439,5 +577,11 @@ mod tests {
         assert_eq!(runtime.base_url, "https://config.example.com");
         assert_eq!(runtime.model.as_deref(), Some("gpt-config"));
         assert!(runtime.env_key.starts_with("CLI_MANAGER_CODEX_PROVIDER_"));
+        assert_eq!(runtime.profile.model_provider, "cloud");
+        assert!(runtime
+            .profile
+            .profile_text
+            .contains(&format!("env_key = \"{}\"", runtime.env_key)));
+        assert!(!runtime.profile.profile_text.contains("sk-secret"));
     }
 }

--- a/src-tauri/src/provider/scope.rs
+++ b/src-tauri/src/provider/scope.rs
@@ -1,19 +1,17 @@
 use super::grok;
 use crate::{
     app_paths,
-    provider::{global, home, repository},
+    provider::{home, repository},
     wsl,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 use sqlx::sqlite::{SqliteConnectOptions, SqliteConnection};
 use sqlx::{Connection, Row};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use toml_edit::DocumentMut;
 use uuid::Uuid;
 
 const GENERATED_ROOT: &str = "generated";
@@ -642,57 +640,22 @@ fn codex_config_overrides(provider_id: &str, effective: &Value) -> Result<Vec<St
     Ok(overrides)
 }
 
-fn codex_profile_name(provider_id: &str) -> String {
-    let mut slug = provider_id
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
-                ch.to_ascii_lowercase()
-            } else {
-                '-'
-            }
-        })
-        .collect::<String>();
-    slug = slug.trim_matches('-').chars().take(40).collect();
-    if slug.is_empty() {
-        slug = "provider".to_string();
-    }
-    let digest = Sha256::digest(provider_id.as_bytes());
-    let hash = format!("{digest:x}");
-    format!("cli-manager-{}-{}", slug, &hash[..10])
-}
-
 fn write_codex_profile(provider_id: &str, effective: &Value) -> Result<String, String> {
     let config_dir = home::default_config_root("codex")
         .ok_or_else(|| "provider_snapshot_write_failed".to_string())?;
-    let (bytes, _) = global::materialize_codex_config(None, effective)?;
-    let mut document = String::from_utf8(bytes)
-        .map_err(|_| "provider_snapshot_write_failed".to_string())?
-        .parse::<DocumentMut>()
+    let settings = serde_json::to_string(effective)
         .map_err(|_| "provider_snapshot_write_failed".to_string())?;
-    let provider_name = document
-        .get("model_provider")
-        .and_then(|value| value.as_str())
-        .filter(|value| !value.trim().is_empty())
-        .unwrap_or("cli_manager")
-        .to_string();
-    let providers = document
-        .get_mut("model_providers")
-        .and_then(|value| value.as_table_mut())
-        .ok_or_else(|| "provider_snapshot_write_failed".to_string())?;
-    let provider = providers
-        .entry(&provider_name)
-        .or_insert(toml_edit::table())
-        .as_table_mut()
-        .ok_or_else(|| "provider_snapshot_write_failed".to_string())?;
-    provider.insert("env_key", toml_edit::value(CODEX_PROVIDER_ENV_KEY));
-    let bytes = document.to_string();
-    let profile_name = codex_profile_name(provider_id);
+    let runtime = crate::provider::runtime::parse_runtime_config(provider_id, &settings)
+        .map_err(|_| "provider_snapshot_write_failed".to_string())?;
+    let profile = runtime
+        .profile
+        .with_env_key(CODEX_PROVIDER_ENV_KEY)
+        .map_err(|_| "provider_snapshot_write_failed".to_string())?;
     write_snapshot_file(
-        &config_dir.join(format!("{}.config.toml", profile_name)),
-        bytes.as_bytes(),
+        &config_dir.join(format!("{}.config.toml", profile.profile_name)),
+        profile.profile_text.as_bytes(),
     )?;
-    Ok(profile_name)
+    Ok(profile.profile_name)
 }
 
 fn write_snapshot_bundle(
@@ -1113,8 +1076,11 @@ mod tests {
 
     #[test]
     fn codex_profile_name_is_stable_and_safe() {
-        let first = codex_profile_name("Provider/One");
-        assert_eq!(first, codex_profile_name("Provider/One"));
+        let first = crate::provider::runtime::codex_profile_name("Provider/One");
+        assert_eq!(
+            first,
+            crate::provider::runtime::codex_profile_name("Provider/One")
+        );
         assert!(first.starts_with("cli-manager-provider-one-"));
         assert!(first
             .chars()

--- a/verification.md
+++ b/verification.md
@@ -904,3 +904,40 @@
 - `node --test scripts/desktopPetSize.test.mjs scripts/desktopPetMenuGeometry.test.mjs scripts/desktopPetTransport.test.mjs scripts/desktopPetStatus.test.mjs`：25 项通过。
 - `npx tsc --noEmit`、`npm run build`、`cargo check`、`cargo fmt -- --check`、`git diff --check`：通过。
 - 当前机器未复现 Issue #196 用户的 WebView2/显示器状态；最终仍需由受影响 Windows 11 机器验证内置小猫和 Codex Pets 在原尺寸设置下的气泡完整性。
+
+## Codex app-server Provider Profile 回归修复（2026-08-14）
+
+### 根因与发现清单
+
+- 根因位于 CLI-Manager 原生 Codex 代理的命令参数边界：提交 `b84a7d68` 为锁定登记 Provider，在公共参数构造器中重新加入 `--profile`；该构造器同时服务 app-server 和普通运行命令，而 Codex 0.147.0 明确禁止 app-server 使用 `--profile`，导致 cc-connect 启动探针以退出码 1 结束。
+- 修改 `src-tauri/src/codex_app_server_proxy.rs`：参数构造按命令类型区分；app-server 只接收完整的 `model_provider`、Provider name、base URL、env key、wire API、模型目录及可选模型 `-c` 覆盖，普通运行命令继续加载生成的 Provider profile。
+- 修改 `src-tauri/src/commands/cc_connect.rs`：删除只为 app-server strict probe 镜像 Provider profile 的失效逻辑；真实 `CODEX_HOME`、登记 Provider 环境、模型目录和密钥脱敏保持不变。
+- 修改 `scripts/codexAppServerProxy.e2e.test.mjs`：锁定 app-server 不得出现 `--profile`，同时保留普通命令必须携带 profile 的断言。
+- 已复核但未修改：微信、Telegram、飞书、企业微信的平台配置与授权、cc-connect 源码及安装、SSH Codex 直连、会话 ID/cwd/Provider 校验、用户消息透传和文件投递上下文。
+- GitNexus 与 codebase-memory MCP 当前未暴露；已按降级规则使用修复契约、`rg`、Git 历史和源码调用点完成影响分析。该启动边界影响全部本地 Codex 远程平台，风险为 HIGH。
+
+### 验证结果
+
+- 本机 Codex CLI 0.147.0：旧参数稳定复现 `--profile only applies to runtime commands`；去掉 profile、保留相同完整 `-c` Provider 覆盖后，`app-server --strict-config --listen stdio://` 正常启动并以 0 退出。
+- 新编译的 Windows `cli-manager-codex-proxy.exe` 使用隔离 `CODEX_HOME`、受管 Provider name 和完整覆盖启动真实 Codex app-server 成功；未发起模型请求。
+- `cargo test codex_app_server_proxy::tests --lib`：21 项通过。
+- `cargo test commands::cc_connect::tests --lib`：48 项通过。
+- `node scripts/codexAppServerProxy.e2e.test.mjs`：4 项通过，使用真实 Windows 原生代理二进制。
+
+## cc-connect Codex 子进程 Provider 密钥转发修复（2026-08-14）
+
+### 根因与发现清单
+
+- 根因位于 CLI-Manager 受管进程环境与 cc-connect Agent 子进程环境的边界：CLI-Manager 只把登记 Provider 的动态密钥变量注入 cc-connect 父进程，却没有写入 `[projects.agent.options.env]`；cc-connect app-server 恢复线程后能选中正确 Provider，但模型请求阶段的 Codex 子进程缺少该变量，因此远程平台持续显示输入中并报 `Missing environment variable`。
+- 日志确认平台消息已接收、Codex app-server 已启动且原 `cliSessionId` 已恢复；项目仍解析到登记 Provider，失败变量名也与该 Provider ID 的派生变量一致，排除了平台凭据、代理、工作目录、Session ID 和 Provider 选择错误。
+- 修改 `build_managed_config_with_codex`：把 Provider 动态变量通过 `${VAR_NAME}` 占位符显式加入 Agent 环境；真实密钥仍只存在于受管进程环境，不写入 `config.toml`、日志或命令行。微信、Telegram、飞书和企业微信复用同一 Codex Agent 配置，因此同时覆盖。
+- 已复核但未修改 app-server 代理参数、`thread/resume` 校验、Provider 数据库/密钥存储、SSH 托管和 cc-connect 源码。
+- GitNexus 与 codebase-memory MCP 当前未暴露；已降级使用 Provider 契约、`rg`、生成配置、运行日志与源码调用点完成影响分析。变更只影响本地 Codex 受管配置生成，风险为中等。
+
+### 验证结果
+
+- `cargo test managed_codex_config_forwards_provider_key_without_persisting_secret`：通过，断言配置包含动态变量占位符且不包含 Provider 密钥、地址或名称。
+- 使用本机 cc-connect `v1.5.0-beta.3` 执行 `managed_config_matches_installed_cc_connect_when_requested`：通过，生成配置可被已安装版本解析和格式化。
+- `cargo test commands::cc_connect::tests --lib`：48 项通过。
+- `cargo fmt --all -- --check`、`git diff --check`：通过，仅有仓库现有 Windows 行尾提示。
+- 用户已完成真实远程托管消息冒烟，确认问题解决。


### PR DESCRIPTION
  ## 变更说明

  修复 CLI-Manager 通过 cc-connect 托管 Codex 会话时的 Provider 配置与密钥传递问题。

  ## 修复内容

  - 远程托管时强制使用项目登记的 Native Provider。
  - 保持原 cliSessionId、工作目录、项目和模型上下文。
  - 修复 Codex 0.147.0 的 app-server 不支持 `--profile` 导致启动失败的问题。
  - app-server 改用完整的 `-c` Provider 配置覆盖，普通 Codex 命令继续使用生成的 profile。
  - 将 Provider 密钥变量显式传入 cc-connect 的 Codex Agent 子进程。
  - 配置文件仅保存 `${VAR_NAME}` 占位符，不落盘 Provider 密钥明文。
  - 保持 Telegram、微信等平台的用户消息原文，不附加额外运行命令。

  ## 根因

  CLI-Manager 原先只将 Provider 密钥变量注入 cc-connect 父进程，没有加入 `[projects.agent.options.env]`。Codex app-
  server 可以恢复原线程，但模型请求阶段的 Agent 子进程缺少对应环境变量，最终报 `Missing environment variable`。

  同时，Codex 0.147.0 已禁止 app-server 使用 `--profile`，因此 Provider 配置需要通过完整的 `-c` 参数注入。

  ## 影响范围

  覆盖所有复用 cc-connect Codex Agent 的平台：

  - Telegram
  - 微信
  - 飞书
  - 企业微信

  SSH 托管、Provider 数据库存储及 cc-connect 源码未修改。

  ## 验证

  - `cargo test commands::cc_connect::tests --lib`：48 项通过
  - `node scripts/codexAppServerProxy.e2e.test.mjs`：4 项通过
  - `tsc --noEmit`：通过
  - `cargo fmt --all -- --check`：通过
  - `git diff --check`：通过
  - 真实远程托管消息测试通过