### PR TITLE
fix(terminal): send Esc+CR newline for Grok composer

### DIFF
--- a/.trellis/tasks/08-31-fix-grok-tui-newline/design.md
+++ b/.trellis/tasks/08-31-fix-grok-tui-newline/design.md
@@ -1,0 +1,24 @@
+# Design: Grok composer newline encoding
+
+## Decision
+
+Extract a pure key-decision helper. Codex and Grok share `\x1b\r`. Unmatched Alt+Enter is passed through only for those sessions.
+
+## Encoding
+
+| Session | Matched shortcut | Unmatched Alt+Enter | Unmatched Shift/Ctrl+Enter |
+|---|---|---|---|
+| Codex / Grok | `\x1b\r` | pass (xterm emits `\x1b\r`) | swallow |
+| Kimi / Shell / others | `\n` | swallow | swallow |
+
+## Recognition
+
+`isGrokTerminalContext` mirrors Codex: sessionTool, projectTool, titleTool, startupCmd (`grok` / `grokbuild` / `grok.exe` / `wsl grok`). Viewport `hasGrokTuiViewport` plus a component latch covers a grok TUI started inside an existing shell.
+
+## Why not author-only `isGrok ? \x1b\r`
+
+That would leave default Shift+Enter users with Alt+Enter still swallowed. The issue asks for Alt+Enter to insert a newline.
+
+## Why not environment branches
+
+Local vs SSH is a symptom of `\n` vs `\x1b\r`, not a transport bug.

--- a/.trellis/tasks/08-31-fix-grok-tui-newline/implement.md
+++ b/.trellis/tasks/08-31-fix-grok-tui-newline/implement.md
@@ -1,0 +1,8 @@
+# Implement
+
+1. Add `isGrokTerminalContext` and `hasGrokTuiViewport`.
+2. Add `resolveTerminalNewlineKeyEvent`.
+3. Wire `XTermTerminal` to the helper; latch Grok like Codex.
+4. Tests for recognition, encoding, pass/swallow, and Kimi exclusion.
+5. CHANGELOG TEMP + 功能清单.
+6. `node --test scripts/terminalComposerNewline.test.mjs` and `npx tsc --noEmit`.

--- a/.trellis/tasks/08-31-fix-grok-tui-newline/prd.md
+++ b/.trellis/tasks/08-31-fix-grok-tui-newline/prd.md
@@ -1,0 +1,52 @@
+# 修复 Grok Build 本地/WSL 换行
+
+## Goal
+
+Grok Build composer 在本地 PowerShell、WSL 与 SSH 上都能用宿主换行快捷键和原生 Alt+Enter 插入换行，而不会把消息提交出去。Refs #236。
+
+## Root-Cause Statement
+
+根因在宿主终端按键编码层：换行快捷键只给 Codex 写 `\x1b\r`，Grok 一律写 `\n`。Linux SSH 上 `\n` 碰巧能当换行，Windows ConPTY / 本地 Grok 把 `\n` 当提交。未匹配的 Alt+Enter 还被 `managedCombo` 吞掉，Grok 原生键到不了进程。修复落在按键决策与会话识别，不改 PTY、不按环境分流。
+
+## State-Dependency
+
+失败依赖：运行环境（本地 pwsh / WSL / SSH）、CLI 类型（Grok / Codex / Kimi / 普通 Shell）、当前换行快捷键设置。必须按场景矩阵覆盖，而不是只修「默认 Shift+Enter + 本地 Grok」。
+
+## Requirements
+
+* Codex 与 Grok 的 composer 换行序列为 `\x1b\r`；Kimi Code 与普通 Shell 保持 `\n`。
+* Grok/Codex 上：匹配到的宿主换行快捷键写 `\x1b\r`；未匹配的 Alt+Enter 放行给 xterm（原生 `\x1b\r`）；未匹配的 Shift/Ctrl+Enter 仍吞掉（漏出去是裸 `\r`，等于提交）。
+* 普通 Shell / Kimi：未匹配的 Alt/Shift/Ctrl+Enter 仍吞掉；匹配时写 `\n`。
+* 识别 Grok 使用与 Codex 同级的会话上下文（cliTool / cli_tool / 标题 / 启动命令，含 `grokbuild`、`grok.exe`、`wsl grok`），并可用 viewport 签名补上「pwsh 里手动打 grok」。
+* 本地、WSL、SSH 走同一决策函数，不写 `if (ssh)` / `if (windows)`。
+* 不把 Kimi 加入 `\x1b\r` 特例。
+
+## Acceptance Criteria
+
+- [ ] 默认 Shift+Enter：Grok 写 `\x1b\r`，不再写 `\n`；Alt+Enter 不吞，交给 xterm。
+- [ ] 快捷键设为 Alt+Enter：Grok 写 `\x1b\r` 且不双重发送。
+- [ ] 快捷键设为 Ctrl+Enter：Grok 写 `\x1b\r`；未匹配的 Shift+Enter 仍吞掉。
+- [ ] Codex 行为与现网一致（匹配快捷键写 `\x1b\r`）。
+- [ ] Kimi 与普通 Shell 仍写 `\n`；未匹配 Alt+Enter 仍吞掉。
+- [ ] `isGrokTerminalContext` 覆盖 grok / grokbuild / grok.exe / wsl grok，不误伤 kimi。
+- [ ] 相关 Node 测试与 `npx tsc --noEmit` 通过。
+- [ ] `CHANGELOG.md`（TEMP）与 `docs/功能清单.md` 更新对应终端输入板块。
+
+## Definition of Done
+
+* Tests added for newline decision and Grok recognition
+* Frontend typecheck green
+* Product change records updated
+* Unrelated dirty files not included
+
+## Out of Scope
+
+* 不改 ConPTY / SSH 传输。
+* 不为 Kimi、Claude、Pi、OpenCode 增加 `\x1b\r`。
+* 不改十字光标 / `mouseEventsRequireAlt`。
+* 不关闭 GitHub issue（commit 用 `Refs #236`）。
+
+## Technical Notes
+
+* 触点：`src/terminal/browser/TerminalCliContext.ts`、`src/terminal/browser/TerminalNewlineShortcut.ts`（新建）、`src/lib/terminalTuiDisplay.ts`、`src/components/XTermTerminal.tsx`、`scripts/terminalComposerNewline.test.mjs`（新建）、`scripts/terminalNewlineShortcut.test.mjs`。
+* 无关：OSC 52、鼠标策略、Kimi hook/history。

--- a/.trellis/tasks/08-31-fix-grok-tui-newline/task.json
+++ b/.trellis/tasks/08-31-fix-grok-tui-newline/task.json
@@ -1,0 +1,32 @@
+{
+  "id": "fix-grok-tui-newline",
+  "name": "fix-grok-tui-newline",
+  "title": "修复 Grok Build 本地/WSL 换行",
+  "description": "Grok/Codex 换行写 \\x1b\\r；Grok/Codex 未匹配 Alt+Enter 放行。Refs #236",
+  "status": "in_progress",
+  "dev_type": null,
+  "scope": null,
+  "package": null,
+  "priority": "P1",
+  "creator": "grok",
+  "assignee": "grok",
+  "createdAt": "2026-08-31",
+  "completedAt": null,
+  "branch": "fix/grok-tui-newline",
+  "base_branch": "master",
+  "worktree_path": null,
+  "commit": null,
+  "pr_url": null,
+  "subtasks": [],
+  "children": [],
+  "parent": null,
+  "relatedFiles": [
+    "src/terminal/browser/TerminalCliContext.ts",
+    "src/terminal/browser/TerminalNewlineShortcut.ts",
+    "src/lib/terminalTuiDisplay.ts",
+    "src/components/XTermTerminal.tsx",
+    "scripts/terminalComposerNewline.test.mjs"
+  ],
+  "notes": "Refs #236",
+  "meta": {}
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [TEMP]
+
+### 修复 Grok Build 本地/WSL 换行
+
+- 宿主换行快捷键对 Codex 与 Grok Build 统一写入 `\x1b\r`（Alt+Enter 编码），不再给 Grok 发 `\n`。本地 PowerShell、WSL 与 SSH 使用同一套按键决策，Grok 不再把 Shift+Enter 当成提交。
+- Grok / Codex 会话上，未匹配的 Alt+Enter 不再吞掉，交给 xterm 发送原生 `\x1b\r`；未匹配的 Shift/Ctrl+Enter 仍拦截，避免漏出裸 `\r`。Kimi Code 与普通 Shell 仍写 `\n`，不加入该特例。
+- Refs #236
+
 ## [V1.3.8] - 2026-08-21
 
 ### 侧边栏底部同步状态单行显示

--- a/docs/功能清单.md
+++ b/docs/功能清单.md
@@ -226,6 +226,7 @@
 ### Codex 终端输入与会话恢复
 
 - 项目直启 Codex、普通终端及右上角新建终端内手动启动 Codex 时，换行组合键统一严格遵循终端快捷键设置；当前可见 TUI 和会话固化 CLI 类型共同参与识别，不再额外要求 Alt 或 Ctrl。
+- Grok Build 与 Codex 共用 composer 换行序列 `\x1b\r`：匹配到的宿主换行快捷键写入该序列，未匹配的 Alt+Enter 放行给 xterm；本地 PowerShell、WSL 与 SSH 行为一致。Kimi Code 与普通 Shell 仍发送 `\n`。
 - 从历史记录“继续对话”创建的 Codex/Claude 等 CLI 终端会立即保存所选 Session ID；Hook 也会对账内存与持久化快照中的真实 ID，首次绑定、切换或磁盘缺失 ID 时立即自愈保存。关闭后恢复多个 Tab 时分别携带各自明确 ID，仅在确实没有 ID 时使用 `--last` / `--continue` 兜底。
 
 ### Hook 任务栏提醒与安装状态
@@ -1551,7 +1552,7 @@ CLI-Manager 是一款面向 Windows 开发者的多项目 CLI 工作台，核心
 - 空绑定不参与冲突检测
 - 恢复默认快捷键
 - 会话历史快捷键可配置
-- 终端换行快捷键可配置
+- 终端换行快捷键可配置；Grok Build / Codex 匹配后写入 `\x1b\r`，未匹配的 Alt+Enter 在这两类会话上放行
 - Tab 切换修饰键可配置
 - Claude/Codex 文件粘贴快捷键可配置，默认 `Alt+V`，支持改为 `Ctrl+V`
 

--- a/scripts/terminalComposerNewline.test.mjs
+++ b/scripts/terminalComposerNewline.test.mjs
@@ -1,0 +1,165 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+
+const tempDir = mkdtempSync(join(tmpdir(), "cli-manager-composer-newline-"));
+process.on("exit", () => rmSync(tempDir, { recursive: true, force: true }));
+
+function transpile(relativePath, outputName) {
+  const output = ts.transpileModule(
+    readFileSync(new URL(relativePath, import.meta.url), "utf8"),
+    {
+      compilerOptions: { module: ts.ModuleKind.ES2022, target: ts.ScriptTarget.ES2022 },
+      fileName: outputName.replace(/\.mjs$/, ".ts"),
+    },
+  ).outputText;
+  const outputPath = join(tempDir, outputName);
+  writeFileSync(outputPath, output, "utf8");
+  return outputPath;
+}
+
+const contextPath = transpile(
+  "../src/terminal/browser/TerminalCliContext.ts",
+  "TerminalCliContext.mjs",
+);
+const newlinePath = transpile(
+  "../src/terminal/browser/TerminalNewlineShortcut.ts",
+  "TerminalNewlineShortcut.mjs",
+);
+
+const {
+  isGrokTerminalContext,
+  isCodexTerminalContext,
+  usesEscCrComposerNewline,
+} = await import(pathToFileURL(contextPath).href);
+const {
+  resolveTerminalNewlineKeyEvent,
+  ESC_CR_COMPOSER_NEWLINE,
+  LF_NEWLINE,
+} = await import(pathToFileURL(newlinePath).href);
+
+const EMPTY = {
+  projectTool: "",
+  sessionTool: "",
+  startupCmd: "",
+  titleTool: "",
+  outputHint: "",
+};
+
+const key = (overrides) => ({
+  type: "keydown",
+  key: "Enter",
+  shiftKey: false,
+  ctrlKey: false,
+  altKey: false,
+  metaKey: false,
+  ...overrides,
+});
+
+test("recognizes Grok from session, project, title, command, and output hint", () => {
+  assert.equal(isGrokTerminalContext({ ...EMPTY, sessionTool: "grok" }), true);
+  assert.equal(isGrokTerminalContext({ ...EMPTY, projectTool: "grokbuild" }), true);
+  assert.equal(isGrokTerminalContext({ ...EMPTY, titleTool: "grok" }), true);
+  assert.equal(isGrokTerminalContext({ ...EMPTY, startupCmd: "wsl grok --resume abc" }), true);
+  assert.equal(isGrokTerminalContext({ ...EMPTY, startupCmd: "grok.exe" }), true);
+  assert.equal(isGrokTerminalContext({ ...EMPTY, startupCmd: "'/opt/Grok Build/grok' --resume x" }), true);
+  assert.equal(isGrokTerminalContext({ ...EMPTY, outputHint: "Welcome to Grok Build" }), true);
+});
+
+test("does not treat Kimi, Codex, or shell as Grok", () => {
+  assert.equal(isGrokTerminalContext({ ...EMPTY, sessionTool: "kimi", startupCmd: "kimi --session 1" }), false);
+  assert.equal(isCodexTerminalContext({ ...EMPTY, sessionTool: "codex" }), true);
+  assert.equal(isGrokTerminalContext({ ...EMPTY, sessionTool: "codex", startupCmd: "codex" }), false);
+  assert.equal(isGrokTerminalContext({ ...EMPTY, startupCmd: "pwsh" }), false);
+});
+
+test("Esc+CR composer newline is Codex or Grok only", () => {
+  assert.equal(usesEscCrComposerNewline({ ...EMPTY, sessionTool: "grok" }), true);
+  assert.equal(usesEscCrComposerNewline({ ...EMPTY, sessionTool: "codex" }), true);
+  assert.equal(usesEscCrComposerNewline({ ...EMPTY, sessionTool: "kimi" }), false);
+  assert.equal(usesEscCrComposerNewline(EMPTY), false);
+});
+
+test("Grok matched Shift+Enter writes Esc+CR", () => {
+  assert.deepEqual(
+    resolveTerminalNewlineKeyEvent(key({ shiftKey: true }), {
+      shortcut: "Shift+Enter",
+      usesEscCrComposerNewline: true,
+    }),
+    { action: "write", data: ESC_CR_COMPOSER_NEWLINE },
+  );
+});
+
+test("Grok unmatched Alt+Enter is passed through", () => {
+  assert.deepEqual(
+    resolveTerminalNewlineKeyEvent(key({ altKey: true }), {
+      shortcut: "Shift+Enter",
+      usesEscCrComposerNewline: true,
+    }),
+    { action: "pass" },
+  );
+});
+
+test("Grok matched Alt+Enter writes Esc+CR once", () => {
+  assert.deepEqual(
+    resolveTerminalNewlineKeyEvent(key({ altKey: true }), {
+      shortcut: "Alt+Enter",
+      usesEscCrComposerNewline: true,
+    }),
+    { action: "write", data: ESC_CR_COMPOSER_NEWLINE },
+  );
+});
+
+test("Grok unmatched Shift+Enter is swallowed", () => {
+  assert.deepEqual(
+    resolveTerminalNewlineKeyEvent(key({ shiftKey: true }), {
+      shortcut: "Alt+Enter",
+      usesEscCrComposerNewline: true,
+    }),
+    { action: "swallow" },
+  );
+});
+
+test("shell and Kimi keep LF and swallow unmatched Alt+Enter", () => {
+  assert.deepEqual(
+    resolveTerminalNewlineKeyEvent(key({ shiftKey: true }), {
+      shortcut: "Shift+Enter",
+      usesEscCrComposerNewline: false,
+    }),
+    { action: "write", data: LF_NEWLINE },
+  );
+  assert.deepEqual(
+    resolveTerminalNewlineKeyEvent(key({ altKey: true }), {
+      shortcut: "Shift+Enter",
+      usesEscCrComposerNewline: false,
+    }),
+    { action: "swallow" },
+  );
+});
+
+test("Alt+Shift+Enter is not a managed newline combo", () => {
+  assert.deepEqual(
+    resolveTerminalNewlineKeyEvent(key({ altKey: true, shiftKey: true }), {
+      shortcut: "Shift+Enter",
+      usesEscCrComposerNewline: true,
+    }),
+    { action: "none" },
+  );
+});
+
+test("XTermTerminal uses the shared newline decision helper", () => {
+  const componentSource = readFileSync(
+    new URL("../src/components/XTermTerminal.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(componentSource, /resolveTerminalNewlineKeyEvent/);
+  assert.match(componentSource, /isGrokSession\(/);
+  assert.doesNotMatch(
+    componentSource,
+    /isCodexSession\([^)]*\) \? "\\x1b\\r" : "\\n"/,
+  );
+});

--- a/scripts/terminalNewlineShortcut.test.mjs
+++ b/scripts/terminalNewlineShortcut.test.mjs
@@ -277,6 +277,8 @@ test("shared CLI context includes immutable session metadata for XTermTerminal",
   assert.match(contextSource, /sessionTool:\s*session\?\.cliTool/u);
   assert.match(contextSource, /sessionTool\s*===\s*"codex"/u);
   assert.match(componentSource, /isCodexSession\(getSessionToolContext\(\), terminal\)/u);
+  assert.match(componentSource, /resolveTerminalNewlineKeyEvent/u);
+  assert.match(componentSource, /isGrokSession\(getSessionToolContext\(\), terminal\)/u);
 });
 
 test("light theme erases a dark CLI message block and keeps light highlights", () => {

--- a/src/components/XTermTerminal.tsx
+++ b/src/components/XTermTerminal.tsx
@@ -51,7 +51,7 @@ import { resolveClaudeImeCompositionAnchor } from "../lib/terminalImeAnchor";
 import { copyTextToClipboard, readTextFromClipboard } from "../lib/systemClipboard";
 import { formatOsc52Reply } from "../lib/terminalOscParse";
 import { eventToCombo } from "../hooks/useKeyboardShortcuts";
-import { hasCodexTuiViewport } from "../lib/terminalTuiDisplay";
+import { hasCodexTuiViewport, hasGrokTuiViewport } from "../lib/terminalTuiDisplay";
 import { createTerminalTuiColorSyncController } from "../lib/terminalTuiColorSync";
 import { hexToRgba, normalizeHexColor } from "../lib/terminalColor";
 import { wrapTerminalPasteTextForCtrlShiftV } from "../lib/terminalKeyboard";
@@ -81,9 +81,11 @@ import {
   createTerminalCliContext,
   isClaudeTerminalContext,
   isCodexTerminalContext,
+  isGrokTerminalContext,
   isOpenCodeTerminalContext,
 } from "../terminal/browser/TerminalCliContext";
 import { createTerminalMouseInteractionOptions } from "../terminal/browser/TerminalMouseInteraction";
+import { resolveTerminalNewlineKeyEvent } from "../terminal/browser/TerminalNewlineShortcut";
 import { attachOpenCodeTuiClipboard } from "../terminal/browser/OpenCodeTuiClipboard";
 import {
   createPiTerminalCompatibility,
@@ -110,6 +112,7 @@ const VISIBILITY_RESTORE_REVEAL_TIMEOUT_MS = 500;
 // ponytail: fixed ceiling bounds untrusted OSC 52 bursts; add per-session rate limiting only if legitimate bursts need it.
 const OSC52_MAX_PENDING_CLIPBOARD_ACTIONS = 32;
 const CODEX_OUTPUT_SIGNATURE_PATTERN = /(?:openai\s+codex|\/model\s+to\s+change)/i;
+const GROK_OUTPUT_SIGNATURE_PATTERN = /grok\s+build/i;
 const ANSI_CSI_SEQUENCE_PATTERN = /\x1b\[[0-?]*[ -/]*[@-~]/g;
 let terminalImageAddonFallbackLogged = false;
 // Minimum time the app must stay in the background before a foreground return
@@ -436,6 +439,7 @@ export function XTermTerminal({ sessionId, isActive = true, isVisible = true, fo
   const visibilityRestoreFallbackRafRef = useRef<number | null>(null);
   const codexCursorShowTimerRef = useRef<number | null>(null);
   const codexSessionDetectedRef = useRef(false);
+  const grokSessionDetectedRef = useRef(false);
   const osc52ClipboardChainRef = useRef(Promise.resolve());
   const osc52ClipboardPendingRef = useRef(0);
   const displayNormalizeOutputRef = useRef<(text: string) => string>((text) => text);
@@ -825,6 +829,18 @@ export function XTermTerminal({ sessionId, isActive = true, isVisible = true, fo
     if (detected) codexSessionDetectedRef.current = true;
     return detected;
   };
+  const isGrokSession = (
+    context = getSessionToolContext(),
+    runtimeTerminal?: Terminal,
+  ) => {
+    const detected = (
+      isGrokTerminalContext(context)
+      || grokSessionDetectedRef.current
+      || (runtimeTerminal !== undefined && hasGrokTuiViewport(runtimeTerminal))
+    );
+    if (detected) grokSessionDetectedRef.current = true;
+    return detected;
+  };
   const shouldHideCodexCursor = (runtimeTerminal = terminalRef.current) => (
     hideCodexRuntimeCursorRef.current
     && runtimeTerminal !== null
@@ -847,6 +863,9 @@ export function XTermTerminal({ sessionId, isActive = true, isVisible = true, fo
     const plainText = text.replace(ANSI_CSI_SEQUENCE_PATTERN, "");
     if (CODEX_OUTPUT_SIGNATURE_PATTERN.test(plainText)) {
       codexSessionDetectedRef.current = true;
+    }
+    if (GROK_OUTPUT_SIGNATURE_PATTERN.test(plainText)) {
+      grokSessionDetectedRef.current = true;
     }
     if (!shouldHideCodexCursor()) return text;
     const cursorPattern = /\x1b\[\?25[hl]/g;
@@ -1099,6 +1118,7 @@ export function XTermTerminal({ sessionId, isActive = true, isVisible = true, fo
   useEffect(() => {
     if (!containerRef.current) return;
     codexSessionDetectedRef.current = false;
+    grokSessionDetectedRef.current = false;
     tuiColorSync.reset();
 
     const baseTheme = withTerminalTextColor(
@@ -1569,24 +1589,23 @@ export function XTermTerminal({ sessionId, isActive = true, isVisible = true, fo
         }
       }
       if (e.type === "keydown" && e.key === "Enter") {
-        const shortcut = useSettingsStore.getState().terminalNewlineShortcut;
-        const managedCombo =
-          (e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey) ||
-          (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey) ||
-          (e.altKey && !e.ctrlKey && !e.shiftKey && !e.metaKey);
-        const matched =
-          (shortcut === "Shift+Enter" && e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey) ||
-          (shortcut === "Ctrl+Enter" && e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey) ||
-          (shortcut === "Alt+Enter" && e.altKey && !e.ctrlKey && !e.shiftKey && !e.metaKey);
-        if (managedCombo) {
+        const newlineDecision = resolveTerminalNewlineKeyEvent(e, {
+          shortcut: useSettingsStore.getState().terminalNewlineShortcut,
+          usesEscCrComposerNewline:
+            isCodexSession(getSessionToolContext(), terminal)
+            || isGrokSession(getSessionToolContext(), terminal),
+        });
+        if (newlineDecision.action === "write") {
           e.preventDefault();
-          if (matched) {
-            markAttentionInputHandled();
-            const newlineData = isCodexSession(getSessionToolContext(), terminal) ? "\x1b\r" : "\n";
-            terminalProcessManager.write(sessionId, newlineData).catch((err) => reportPtyWriteError("newline", err));
-          }
+          markAttentionInputHandled();
+          terminalProcessManager.write(sessionId, newlineDecision.data).catch((err) => reportPtyWriteError("newline", err));
           return false;
         }
+        if (newlineDecision.action === "swallow") {
+          e.preventDefault();
+          return false;
+        }
+        if (newlineDecision.action === "pass") return true;
       }
       if (
         e.type === "keydown" &&

--- a/src/lib/terminalTuiDisplay.ts
+++ b/src/lib/terminalTuiDisplay.ts
@@ -16,6 +16,7 @@ const SLASH_COMMAND_MENU_LINE_PATTERN = /^\/[a-z0-9][a-z0-9:_-]*(?:\s|$)/i;
 // A single dark cell can be a TUI block cursor; a painted block always spans several.
 const DARK_BLOCK_MIN_CELLS = 4;
 const CODEX_TUI_VIEWPORT_PATTERN = /(?:openai\s+codex|\/model\s+to\s+change)/i;
+const GROK_TUI_VIEWPORT_PATTERN = /grok\s+build/i;
 const OTHER_AI_TUI_VIEWPORT_PATTERN = /(?:claude\s+code|yolo\s+mode)/i;
 
 type MutableXtermCell = IBufferCell & {
@@ -61,6 +62,15 @@ export function hasCodexTuiViewport(terminal: Terminal): boolean {
   for (let row = 0; row < terminal.rows; row += 1) {
     const line = buffer.getLine(buffer.viewportY + row);
     if (line && CODEX_TUI_VIEWPORT_PATTERN.test(line.translateToString(true))) return true;
+  }
+  return false;
+}
+
+export function hasGrokTuiViewport(terminal: Terminal): boolean {
+  const buffer = terminal.buffer.active;
+  for (let row = 0; row < terminal.rows; row += 1) {
+    const line = buffer.getLine(buffer.viewportY + row);
+    if (line && GROK_TUI_VIEWPORT_PATTERN.test(line.translateToString(true))) return true;
   }
   return false;
 }

--- a/src/terminal/browser/TerminalCliContext.ts
+++ b/src/terminal/browser/TerminalCliContext.ts
@@ -2,6 +2,8 @@ import type { Project, TerminalSession } from "../../lib/types";
 
 const CODEX_COMMAND_PATTERN = /(?:^|\s)codex(?:\.(?:cmd|exe|ps1))?(?:\s|$)/i;
 const CLAUDE_COMMAND_PATTERN = /(?:^|\s)claude(?:\.(?:cmd|exe|ps1))?(?:\s|$)/i;
+const GROK_COMMAND_PATTERN = /(?:^|\s)grok(?:\.(?:cmd|exe|ps1))?(?:\s|$)/i;
+const GROK_OUTPUT_SIGNATURE_PATTERN = /grok\s+build/i;
 const PI_COMMAND_PATTERN = /^\s*(?:&\s*)?pi(?:\.(?:cmd|exe|ps1))?(?:\s|$)/i;
 const OPENCODE_TOOL_VALUES = new Set(["opencode", "opencode.cmd", "opencode.exe", "opencode.ps1"]);
 const OPENCODE_COMMAND_PATTERN = /^opencode(?:\.(?:cmd|exe|ps1))?$/i;
@@ -31,6 +33,11 @@ const isOpenCodeToolValue = (value: string): boolean => (
 const hasPiOutputSignature = (text: string): boolean => {
   CSI_PATTERN.lastIndex = 0;
   return PI_OUTPUT_SIGNATURE_PATTERN.test(text.replace(CSI_PATTERN, ""));
+};
+
+const hasGrokOutputSignature = (text: string): boolean => {
+  CSI_PATTERN.lastIndex = 0;
+  return GROK_OUTPUT_SIGNATURE_PATTERN.test(text.replace(CSI_PATTERN, ""));
 };
 
 export const createTerminalCliContext = (
@@ -68,6 +75,34 @@ export const isClaudeTerminalContext = ({
 
 export const isClaudeOrCodexTerminalContext = (context: TerminalCliContext): boolean => (
   isCodexTerminalContext(context) || isClaudeTerminalContext(context)
+);
+
+const isGrokToolValue = (value: string): boolean => {
+  const trimmed = value.trim().toLowerCase();
+  return trimmed === "grok" || trimmed === "grokbuild" || trimmed.includes("grokbuild");
+};
+
+export const isGrokTerminalContext = ({
+  projectTool,
+  sessionTool,
+  startupCmd,
+  titleTool,
+  outputHint = "",
+}: TerminalCliContext): boolean => {
+  const startupToken = commandExecutableToken(startupCmd).toLowerCase();
+  return isGrokToolValue(sessionTool)
+    || isGrokToolValue(projectTool)
+    || isGrokToolValue(titleTool)
+    || startupToken === "grok"
+    || startupToken === "grok.exe"
+    || startupToken === "grok.cmd"
+    || startupToken === "grok.ps1"
+    || GROK_COMMAND_PATTERN.test(startupCmd)
+    || hasGrokOutputSignature(outputHint);
+};
+
+export const usesEscCrComposerNewline = (context: TerminalCliContext): boolean => (
+  isCodexTerminalContext(context) || isGrokTerminalContext(context)
 );
 
 export const isPiTerminalContext = ({

--- a/src/terminal/browser/TerminalNewlineShortcut.ts
+++ b/src/terminal/browser/TerminalNewlineShortcut.ts
@@ -1,0 +1,50 @@
+export type ComposerNewlineShortcut = "Shift+Enter" | "Ctrl+Enter" | "Alt+Enter";
+
+export const ESC_CR_COMPOSER_NEWLINE = "\x1b\r";
+export const LF_NEWLINE = "\n";
+
+export interface TerminalNewlineKeyEvent {
+  type: string;
+  key: string;
+  shiftKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+}
+
+export type TerminalNewlineKeyDecision =
+  | { action: "none" }
+  | { action: "write"; data: string }
+  | { action: "swallow" }
+  | { action: "pass" };
+
+export const resolveTerminalNewlineKeyEvent = (
+  event: TerminalNewlineKeyEvent,
+  options: {
+    shortcut: ComposerNewlineShortcut;
+    usesEscCrComposerNewline: boolean;
+  },
+): TerminalNewlineKeyDecision => {
+  if (event.type !== "keydown" || event.key !== "Enter" || event.metaKey) {
+    return { action: "none" };
+  }
+
+  const isShiftEnter = event.shiftKey && !event.ctrlKey && !event.altKey;
+  const isCtrlEnter = event.ctrlKey && !event.shiftKey && !event.altKey;
+  const isAltEnter = event.altKey && !event.ctrlKey && !event.shiftKey;
+  if (!isShiftEnter && !isCtrlEnter && !isAltEnter) return { action: "none" };
+
+  const matched =
+    (options.shortcut === "Shift+Enter" && isShiftEnter)
+    || (options.shortcut === "Ctrl+Enter" && isCtrlEnter)
+    || (options.shortcut === "Alt+Enter" && isAltEnter);
+  if (matched) {
+    return {
+      action: "write",
+      data: options.usesEscCrComposerNewline ? ESC_CR_COMPOSER_NEWLINE : LF_NEWLINE,
+    };
+  }
+
+  if (isAltEnter && options.usesEscCrComposerNewline) return { action: "pass" };
+  return { action: "swallow" };
+};


### PR DESCRIPTION
## Summary

- Host newline shortcut writes `\x1b\r` for Grok Build and Codex, not `\n`. Local/WSL ConPTY often turns `\n` into `\r` (submit); Esc+CR is Grok’s Alt+Enter newline.
- Unmatched Alt+Enter is passed through on Grok/Codex so the native key works when the setting is still Shift+Enter. Unmatched Shift/Ctrl+Enter stay swallowed.
- Kimi Code and plain shells still get `\n`.

Refs #236

## Test plan

- [x] `node --test scripts/terminalComposerNewline.test.mjs` (Grok/Codex Esc+CR, Kimi/shell LF, Alt+Enter pass-through)
- [x] `npx tsc --noEmit`
- [x] Linux PTY: real Grok 1.0.13 — `\r` submits, `\n` and `\x1b\r` insert a line
- [ ] Windows CLI-Manager: local pwsh Grok — Shift+Enter and Alt+Enter insert a line, Enter still sends
- [ ] Windows CLI-Manager WSL Grok — same as local
- [ ] SSH Grok — newline still works; Kimi/shell Shift+Enter still `\n`